### PR TITLE
Bug fix: fixed-point conversion was not using entire range for signed integer types

### DIFF
--- a/openvdb_points/tools/AttributeArray.h
+++ b/openvdb_points/tools/AttributeArray.h
@@ -77,9 +77,11 @@ template <typename IntegerT, typename FloatT>
 inline IntegerT
 floatingPointToFixedPoint(const FloatT s)
 {
+    const FloatT MinF = FloatT(std::numeric_limits<IntegerT>::min());
+    const FloatT RangeF = FloatT(std::numeric_limits<IntegerT>::max()) - MinF;
     if (FloatT(0.0) > s) return std::numeric_limits<IntegerT>::min();
     else if (FloatT(1.0) <= s) return std::numeric_limits<IntegerT>::max();
-    return IntegerT(std::floor(s * FloatT(std::numeric_limits<IntegerT>::max())));
+    return IntegerT(std::floor((s * RangeF) + MinF));
 }
 
 
@@ -87,7 +89,9 @@ template <typename FloatT, typename IntegerT>
 inline FloatT
 fixedPointToFloatingPoint(const IntegerT s)
 {
-    return FloatT(s) / FloatT((std::numeric_limits<IntegerT>::max()));
+    const FloatT MinF = FloatT(std::numeric_limits<IntegerT>::min());
+    const FloatT RangeF = FloatT(std::numeric_limits<IntegerT>::max()) - MinF;
+    return (FloatT(s) - MinF) / RangeF;
 }
 
 

--- a/openvdb_points/unittest/TestAttributeArray.cc
+++ b/openvdb_points/unittest/TestAttributeArray.cc
@@ -46,14 +46,24 @@ class TestAttributeArray: public CppUnit::TestCase
 public:
     CPPUNIT_TEST_SUITE(TestAttributeArray);
     CPPUNIT_TEST(testFixedPointConversion);
+    CPPUNIT_TEST(testFixedPointUsesEntireRangeForSignedIntegerTypes);
+    CPPUNIT_TEST(testFixedPointUsesEntireRangeForUnsignedIntegerTypes);
     CPPUNIT_TEST(testAttributeArray);
     CPPUNIT_TEST(testAttributeHandle);
 
     CPPUNIT_TEST_SUITE_END();
 
     void testFixedPointConversion();
+    void testFixedPointUsesEntireRangeForSignedIntegerTypes();
+    void testFixedPointUsesEntireRangeForUnsignedIntegerTypes();
     void testAttributeArray();
     void testAttributeHandle();
+
+private:
+
+    template <class IntegerT>
+    void ensureFixedPointUsesEntireIntegerRange();
+
 }; // class TestPointDataGrid
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAttributeArray);
@@ -103,6 +113,36 @@ TestAttributeArray::testFixedPointConversion()
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(value, newValue, /*tolerance=*/1e-6);
 }
+
+
+template <class IntegerT>
+void TestAttributeArray::ensureFixedPointUsesEntireIntegerRange()
+{
+    IntegerT minimumFixedPoint = openvdb::tools::floatingPointToFixedPoint<IntegerT,float>(0.0f);
+    CPPUNIT_ASSERT_EQUAL(std::numeric_limits<IntegerT>::min(), minimumFixedPoint);
+
+    IntegerT maximumFixedPoint = openvdb::tools::floatingPointToFixedPoint<IntegerT,float>(1.0f);
+    CPPUNIT_ASSERT_EQUAL(std::numeric_limits<IntegerT>::max(), maximumFixedPoint);
+}
+
+
+void TestAttributeArray::testFixedPointUsesEntireRangeForSignedIntegerTypes()
+{
+    ensureFixedPointUsesEntireIntegerRange<int8_t>();
+    ensureFixedPointUsesEntireIntegerRange<int16_t>();
+    ensureFixedPointUsesEntireIntegerRange<int32_t>();
+    ensureFixedPointUsesEntireIntegerRange<int64_t>();
+}
+
+
+void TestAttributeArray::testFixedPointUsesEntireRangeForUnsignedIntegerTypes()
+{
+    ensureFixedPointUsesEntireIntegerRange<uint8_t>();
+    ensureFixedPointUsesEntireIntegerRange<uint16_t>();
+    ensureFixedPointUsesEntireIntegerRange<uint32_t>();
+    ensureFixedPointUsesEntireIntegerRange<uint64_t>();
+}
+
 
 void
 TestAttributeArray::testAttributeArray()


### PR DESCRIPTION
I have uncovered a bug in the fixed-point codecs, in which the full integer range was not being utilised when compressing to signed integer types. So for example, 8-bit fixed-point compression using int8_t was only utilising 7 bits. This pull request contains a fix for this bug, and some unit tests to verify the fix.

Note that this is a significant change as it violates the interpretation of any existing fixed-point compressed point data grids that have already been written...