### PR TITLE
Fixing memory leaks in PointConversion and tests

### DIFF
--- a/openvdb_points/tools/PointConversion.h
+++ b/openvdb_points/tools/PointConversion.h
@@ -210,8 +210,9 @@ struct PopulatePositionAttributeOp {
 
             if (!pointIndexLeaf)    continue;
 
-            AttributeWriteHandle<ValueType>* attributeWriteHandle =
-                leaf->template attributeWriteHandle<ValueType>("P");
+            std::auto_ptr<AttributeWriteHandle<ValueType> > attributeWriteHandle(
+                leaf->template attributeWriteHandle<ValueType>("P")
+            );
 
             Index64 index = 0;
 
@@ -273,8 +274,9 @@ struct PopulateAttributeOp {
 
             if (!pointIndexLeaf)    continue;
 
-            AttributeWriteHandle<ValueType>* attributeWriteHandle =
-                leaf->template attributeWriteHandle<ValueType>(mAttributeName);
+            std::auto_ptr<AttributeWriteHandle<ValueType> > attributeWriteHandle(
+                leaf->template attributeWriteHandle<ValueType>(mAttributeName)
+            );
 
             Index64 index = 0;
 

--- a/openvdb_points/unittest/TestPointConversion.cc
+++ b/openvdb_points/unittest/TestPointConversion.cc
@@ -298,8 +298,8 @@ TestPointConversion::testPointConversion()
 
     for (; leafIter; ++leafIter) {
 
-        AttributeHandle<Vec3f>* posHandle = leafIter->attributeHandle<Vec3f>("P");
-        AttributeHandle<int32_t>* idHandle = leafIter->attributeHandle<int32_t>("id");
+        std::auto_ptr<AttributeHandle<Vec3f> > posHandle(leafIter->attributeHandle<Vec3f>("P"));
+        std::auto_ptr<AttributeHandle<int32_t> > idHandle(leafIter->attributeHandle<int32_t>("id"));
 
         for (PointDataTree::LeafNodeType::ValueOnCIter valueIter = leafIter->cbeginValueOn(); valueIter; ++valueIter) {
 

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -238,6 +238,8 @@ TestPointDataLeaf::testOffsets()
 
         CPPUNIT_ASSERT(leafNode->getValue(10) == 10);
         CPPUNIT_ASSERT(leafNode->isDense());
+
+        delete leafNode;
     }
 
     // offsets for one point per voxel (active = false)
@@ -251,6 +253,8 @@ TestPointDataLeaf::testOffsets()
 
         CPPUNIT_ASSERT(leafNode->getValue(10) == 10);
         CPPUNIT_ASSERT(leafNode->isEmpty());
+
+        delete leafNode;
     }
 }
 


### PR DESCRIPTION
In switching over to the public repo, I uncovered the following memory leaks...