### PR TITLE
Exposing AttributeSet::dropAttributes via the PointDataLeafNode

### DIFF
--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -321,6 +321,14 @@ public:
         mAttributeSet->appendAttribute(attribute, expected, replacement);
     }
 
+    /// @brief Remove attributes located at the indices given in @a indices. Creates a new
+    /// descriptor for the underlying attribute set.
+    /// @param indices    The indices of the attributes that should be removed
+    void dropAttributes(const std::vector<size_t>& indices)
+    {
+        mAttributeSet->dropAttributes(indices);
+    }
+
     template <typename AttributeType>
     typename AttributeWriteHandle<AttributeType>::Ptr attributeWriteHandle(const size_t pos)
     {

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -329,7 +329,7 @@ public:
     }
 
     /// @brief Drop attributes with @a pos indices.
-    /// Requires the current descriptor to match @a expacted
+    /// Requires the current descriptor to match @a expected
     /// On drop, current descriptor is replaced with @a replacement
     void dropAttributes(const std::vector<size_t>& pos,
                         const Descriptor& expected, Descriptor::Ptr& replacement)

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -328,12 +328,13 @@ public:
         mAttributeSet->appendAttribute(attribute, expected, replacement);
     }
 
-    /// @brief Remove attributes located at the indices given in @a indices. Creates a new
-    /// descriptor for the underlying attribute set.
-    /// @param indices    The indices of the attributes that should be removed
-    void dropAttributes(const std::vector<size_t>& indices)
+    /// @brief Drop attributes with @a pos indices.
+    /// Requires the current descriptor to match @a expacted
+    /// On drop, current descriptor is replaced with @a replacement
+    void dropAttributes(const std::vector<size_t>& pos,
+                        const Descriptor& expected, Descriptor::Ptr& replacement)
     {
-        mAttributeSet->dropAttributes(indices);
+        mAttributeSet->dropAttributes(pos, expected, replacement);
     }
 
     template <typename AttributeType>

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -52,7 +52,6 @@ public:
     CPPUNIT_TEST(testTopologyCopy);
     CPPUNIT_TEST(testEquivalence);
     CPPUNIT_TEST(testIO);
-    CPPUNIT_TEST(testDropAttributes);
     CPPUNIT_TEST_SUITE_END();
 
     void testEmptyLeaf();
@@ -64,7 +63,6 @@ public:
     void testTopologyCopy();
     void testEquivalence();
     void testIO();
-    void testDropAttributes();
 
 private:
     // Generate random points by uniformly distributing points
@@ -844,55 +842,6 @@ TestPointDataLeaf::testIO()
         CPPUNIT_ASSERT_EQUAL(leaf2.getValue(4), ValueType(20));
         CPPUNIT_ASSERT_EQUAL(leaf2.attributeSet().size(), size_t(2));
     }
-}
-
-
-void TestPointDataLeaf::testDropAttributes()
-{
-    using namespace openvdb::tools;
-
-    // Define and register some common attribute types
-
-    typedef TypedAttributeArray<float>    AttributeS;
-    typedef TypedAttributeArray<int32_t>  AttributeI;
-
-    AttributeS::registerType();
-    AttributeI::registerType();
-
-    // create a descriptor
-
-    typedef AttributeSet::Descriptor Descriptor;
-
-    Descriptor::Inserter names;
-    names.add("density", AttributeS::attributeType());
-    names.add("id", AttributeI::attributeType());
-
-    Descriptor::Ptr descrA = Descriptor::create(names.vec);
-
-    // create a leaf and initialize attributes using this descriptor
-
-    LeafType leaf(openvdb::Coord(0, 0, 0));
-    leaf.initializeAttributes(descrA, /*arrayLength=*/100);
-
-    // ensure both attributes exist on the leaf node
-
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>("density"));
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>("id"));
-
-    // drop density attribute
-
-    std::vector<size_t> indices;
-    indices.push_back(0);
-
-    const AttributeSet::Descriptor& expected = leaf.attributeSet().descriptor();
-    Descriptor::Ptr descrB = expected.duplicateDrop(indices);
-
-    leaf.dropAttributes(indices, expected, descrB);
-
-    // ensure only id remains
-
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>("density") == false);
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>("id") == true);
 }
 
 

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -52,6 +52,7 @@ public:
     CPPUNIT_TEST(testTopologyCopy);
     CPPUNIT_TEST(testEquivalence);
     CPPUNIT_TEST(testIO);
+    CPPUNIT_TEST(testDropAttributes);
     CPPUNIT_TEST_SUITE_END();
 
     void testEmptyLeaf();
@@ -63,6 +64,7 @@ public:
     void testTopologyCopy();
     void testEquivalence();
     void testIO();
+    void testDropAttributes();
 
 private:
     // Generate random points by uniformly distributing points
@@ -842,6 +844,55 @@ TestPointDataLeaf::testIO()
         CPPUNIT_ASSERT_EQUAL(leaf2.getValue(4), ValueType(20));
         CPPUNIT_ASSERT_EQUAL(leaf2.attributeSet().size(), size_t(2));
     }
+}
+
+
+void TestPointDataLeaf::testDropAttributes()
+{
+    using namespace openvdb::tools;
+
+    // Define and register some common attribute types
+
+    typedef TypedAttributeArray<float>    AttributeS;
+    typedef TypedAttributeArray<int32_t>  AttributeI;
+
+    AttributeS::registerType();
+    AttributeI::registerType();
+
+    // create a descriptor
+
+    typedef AttributeSet::Descriptor Descriptor;
+
+    Descriptor::Inserter names;
+    names.add("density", AttributeS::attributeType());
+    names.add("id", AttributeI::attributeType());
+
+    Descriptor::Ptr descrA = Descriptor::create(names.vec);
+
+    // create a leaf and initialize attributes using this descriptor
+
+    LeafType leaf(openvdb::Coord(0, 0, 0));
+    leaf.initializeAttributes(descrA, /*arrayLength=*/100);
+
+    // ensure both attributes exist on the leaf node
+
+    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>("density"));
+    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>("id"));
+
+    // drop density attribute
+
+    std::vector<size_t> indices;
+    indices.push_back(0);
+
+    const AttributeSet::Descriptor& expected = leaf.attributeSet().descriptor();
+    Descriptor::Ptr descrB = expected.duplicateDrop(indices);
+
+    leaf.dropAttributes(indices, expected, descrB);
+
+    // ensure only id remains
+
+    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>("density") == false);
+    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>("id") == true);
 }
 
 


### PR DESCRIPTION
This is related to my previous pull request (exposing copyAttributeValues), but more general and useful I think. In the future we'll be adding the point sort and merge algorithms, as well as the Points Attribute SOP - these rely on being able to create and remove attributes from an existing PointDataLeafNode...