### PR TITLE
Reorder attributes

### DIFF
--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -282,6 +282,28 @@ AttributeSet::dropAttributes(   const std::vector<size_t>& pos,
 
 
 void
+AttributeSet::reorderAttributes(const DescriptorPtr& replacement)
+{
+    if (!mDescr->hasSameAttributes(*replacement)) {
+        OPENVDB_THROW(LookupError, "Cannot reorder attributes as descriptors do not contain the same attributes.")
+    }
+
+    AttrArrayVec attrs(replacement->size());
+
+    // compute target indices for attributes from the given decriptor
+    for (Descriptor::ConstIterator it = mDescr->map().begin(),
+        end = mDescr->map().end(); it != end; ++it) {
+        const size_t index = replacement->find(it->first);
+        attrs[index] = AttributeArray::Ptr(mAttrs[it->second]);
+    }
+
+    // copy the ordering to the member attributes vector and update descriptor to be target
+    std::copy(attrs.begin(), attrs.end(), mAttrs.begin());
+    mDescr = replacement;
+}
+
+
+void
 AttributeSet::read(std::istream& is)
 {
     this->readMetadata(is);

--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -377,6 +377,29 @@ AttributeSet::Descriptor::operator==(const Descriptor& rhs) const
 }
 
 
+bool
+AttributeSet::Descriptor::hasSameAttributes(const Descriptor& rhs) const
+{
+    if (this == &rhs) return true;
+
+    if (mTypes.size()   != rhs.mTypes.size() ||
+        mNameMap.size() != rhs.mNameMap.size()) {
+        return false;
+    }
+
+    for (NameToPosMap::const_iterator it = mNameMap.begin(),
+        end = mNameMap.end(); it != end; ++it) {
+        const size_t index = rhs.find(it->first);
+
+        if (index == INVALID_POS) return false;
+
+        if (mTypes[it->second] != rhs.mTypes[index]) return false;
+    }
+
+    return true;
+}
+
+
 size_t
 AttributeSet::Descriptor::memUsage() const
 {

--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -177,6 +177,10 @@ public:
     void dropAttributes(const std::vector<size_t>& pos,
                         const Descriptor& expected, DescriptorPtr& replacement);
 
+    /// Re order attribute set to match a provided descriptor
+    /// Replaces own descriptor with @a replacement
+    void reorderAttributes(const DescriptorPtr& replacement);
+
     /// Read the entire set from a stream.
     void read(std::istream&);
     /// Write the entire set to a stream.

--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -277,6 +277,9 @@ public:
     bool operator==(const Descriptor&) const;
     /// Return true if this descriptor is not equal to the given one.
     bool operator!=(const Descriptor& rhs) const { return !this->operator==(rhs); }
+    /// Return true if this descriptor contains the same attributes
+    /// as the given descriptor, ignoring attribute order
+    bool hasSameAttributes(const Descriptor& rhs) const;
 
     /// Return a reference to the name-to-position map.
     const NameToPosMap& map() const { return mNameMap; }

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -337,6 +337,13 @@ public:
         mAttributeSet->dropAttributes(pos, expected, replacement);
     }
 
+    /// @brief Reorder attribute set based on a decriptor which contains
+    /// the same attributes in a different order
+    void reorderAttributes(const Descriptor::Ptr& replacement)
+    {
+        mAttributeSet->reorderAttributes(replacement);
+    }
+
     template <typename AttributeType>
     typename AttributeWriteHandle<AttributeType>::Ptr attributeWriteHandle(const size_t pos)
     {

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -152,6 +152,42 @@ TestAttributeSet::testAttributeSetDescriptor()
         CPPUNIT_ASSERT_EQUAL(itA->type.second, itB->type.second);
     }
 
+     // Test hasSameAttributes
+    {
+        Descriptor::Ptr descr1 = Descriptor::create(Descriptor::Inserter()
+                .add("pos", AttributeD::attributeType())
+                .add("test", AttributeI::attributeType())
+                .add("id", AttributeI::attributeType())
+                .vec);
+
+        // Test same names with different types, should be false
+        Descriptor::Ptr descr2 = Descriptor::create(Descriptor::Inserter()
+                .add("pos", AttributeD::attributeType())
+                .add("test", AttributeS::attributeType())
+                .add("id", AttributeI::attributeType())
+                .vec);
+
+        CPPUNIT_ASSERT(!descr1->hasSameAttributes(*descr2));
+
+        // Test different names, should be false
+        Descriptor::Ptr descr3 = Descriptor::create(Descriptor::Inserter()
+                .add("pos", AttributeD::attributeType())
+                .add("test2", AttributeI::attributeType())
+                .add("id", AttributeI::attributeType())
+                .vec);
+
+        CPPUNIT_ASSERT(!descr1->hasSameAttributes(*descr3));
+
+        // Test same names and types but different order, should be true
+        Descriptor::Ptr descr4 = Descriptor::create(Descriptor::Inserter()
+                .add("test", AttributeI::attributeType())
+                .add("id", AttributeI::attributeType())
+                .add("pos", AttributeD::attributeType())
+                .vec);
+
+        CPPUNIT_ASSERT(descr1->hasSameAttributes(*descr4));
+    }
+
     // I/O test
 
     std::ostringstream ostr(std::ios_base::binary);

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -440,6 +440,31 @@ TestAttributeSet::testAttributeSet()
 
     CPPUNIT_ASSERT_EQUAL(size_t(10), attrSetA.get(1)->size());
 
+    { // reorder attribute set
+        Descriptor::Ptr descr1 = Descriptor::create(Descriptor::Inserter()
+                .add("pos", AttributeVec3s::attributeType())
+                .add("test", AttributeI::attributeType())
+                .add("id", AttributeI::attributeType())
+                .add("test2", AttributeI::attributeType())
+                .vec);
+
+        Descriptor::Ptr descr2 = Descriptor::create(Descriptor::Inserter()
+                .add("test2", AttributeI::attributeType())
+                .add("test", AttributeI::attributeType())
+                .add("pos", AttributeVec3s::attributeType())
+                .add("id", AttributeI::attributeType())
+                .vec);
+
+        AttributeSet attrSetA(descr1);
+        AttributeSet attrSetB(descr2);
+
+        CPPUNIT_ASSERT(attrSetA != attrSetB);
+
+        attrSetB.reorderAttributes(descr1);
+
+        CPPUNIT_ASSERT(attrSetA == attrSetB);
+    }
+
     // I/O test
 
     std::ostringstream ostr(std::ios_base::binary);
@@ -451,7 +476,6 @@ TestAttributeSet::testAttributeSet()
 
     CPPUNIT_ASSERT(matchingAttributeSets(attrSetA, attrSetB));
 }
-
 
 // Copyright (c) 2015 Double Negative Visual Effects
 // All rights reserved. This software is distributed under the


### PR DESCRIPTION
This is an additional function for attribute sets to be re-ordered based on a given descriptor. An additional comparison hasSameAttributes is provided on the Descriptor class. These changes are to facilitate merging attributes sets with the same attributes in a different order.