### PR TITLE
Added typeNameAsString<uint16_t> for UnitVecAttributeCodec

### DIFF
--- a/openvdb_points/Types.h
+++ b/openvdb_points/Types.h
@@ -44,6 +44,7 @@ namespace OPENVDB_VERSION_NAME {
 
 template<> inline const char* typeNameAsString<half>()                   { return "half"; }
 template<> inline const char* typeNameAsString<int16_t>()                { return "int16"; }
+template<> inline const char* typeNameAsString<uint16_t>()               { return "uint16"; }
 template<> inline const char* typeNameAsString<math::Vec3<half> >()      { return "vec3h"; }
 template<> inline const char* typeNameAsString<math::Vec3<uint8_t> >()   { return "vec3u8"; }
 template<> inline const char* typeNameAsString<math::Vec3<uint16_t> >()  { return "vec3u16"; }


### PR DESCRIPTION
At the moment, ```TypedAttributeArray<Vec3f, UnitVecAttributeCodec>::attributeType().second``` yields "uvec_t" because the codec's storage type (uint16_t) doesn't have a typeNameAsString implementation.

Here, we're simply introducing a typeNameAsString implementation that is consistent with the other integer types we use, such that the above yields "uvec_uint16" instead...