### PR TITLE
Removing AttributeSet::copyAttributeValues

### DIFF
--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -188,24 +188,6 @@ AttributeSet::makeUnique(size_t pos)
 }
 
 
-void
-AttributeSet::copyAttributeValues(const Index n, const AttributeSet& attributeSet, const Index source)
-{
-    const Descriptor& sourceDescriptor = attributeSet.descriptor();
-
-    if (sourceDescriptor != *mDescr) {
-        OPENVDB_THROW(LookupError, "Attribute set descriptors are not equal.");
-    }
-
-    // copy the attribute values for each attribute array
-
-    for (size_t i = 0; i < this->size(); i++) {
-        AttributeArray* array = this->get(i);
-        array->set(n, *attributeSet.getConst(i), source);
-    }
-}
-
-
 AttributeArray::Ptr
 AttributeSet::appendAttribute(const Descriptor::NameAndType& attribute)
 {

--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -155,9 +155,6 @@ public:
     ///         shared with anyone else.
     void makeUnique(size_t pos);
 
-    /// Copy attribute values for a target index @a n from another @a attributeSet for index @a source
-    void copyAttributeValues(const Index n, const AttributeSet& attributeSet, const Index source);
-
     /// Append attribute @a attribute (simple method)
     AttributeArray::Ptr appendAttribute(const Util::NameAndType& attribute);
 

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -275,58 +275,6 @@ TestAttributeSet::testAttributeSet()
         CPPUNIT_ASSERT(!attrSetB.isShared(1));
     }
 
-    { // value copy
-        AttributeSet attrSetB(attrSetA);
-        AttributeSet attrSetC(attrSetA);
-
-        attrSetB.makeUnique(0);
-        attrSetB.makeUnique(1);
-        attrSetC.makeUnique(0);
-        attrSetC.makeUnique(1);
-
-        AttributeVec3s* attrB0 = static_cast<AttributeVec3s*>(attrSetB.get(0));
-        AttributeI* attrB1 = static_cast<AttributeI*>(attrSetB.get(1));
-
-        // assign arbitrary values to pos and id
-
-        for (openvdb::Index i = 0; i < 50; i++) {
-            attrB0->set(i, openvdb::Vec3s(i, i+50, i+100));
-            attrB1->set(i, int(i));
-        }
-
-        // copy attribute values from attrSetB to attrSetC with an offset of 10 modulo
-
-        for (openvdb::Index i = 0; i < 50; i++) {
-            openvdb::Index offset = (i + 10) % 50;
-            attrSetC.copyAttributeValues(i, attrSetB, offset);
-        }
-
-        // verify attribute set arrays match only when using the correct offset
-
-        AttributeVec3s* attrC0 = static_cast<AttributeVec3s*>(attrSetC.get(0));
-        AttributeI* attrC1 = static_cast<AttributeI*>(attrSetC.get(1));
-
-        for (openvdb::Index i = 0; i < 50; i++) {
-            openvdb::Index offset = (i + 10) % 50;
-
-            CPPUNIT_ASSERT(attrC0->get(i) != attrB0->get(i));
-            CPPUNIT_ASSERT(attrC1->get(i) != attrB1->get(i));
-
-            CPPUNIT_ASSERT_EQUAL(attrC0->get(i), attrB0->get(offset));
-            CPPUNIT_ASSERT_EQUAL(attrC1->get(i), attrB1->get(offset));
-        }
-
-        // ensure an attempt to copy values for attribute sets with mis-matching descriptors throws
-
-        Descriptor::Ptr descrD = Descriptor::create(Descriptor::Inserter()
-        .add("pos", AttributeVec3s::attributeType())
-        .vec);
-
-        AttributeSet attrSetD(descrD, /*arrayLength=*/50);
-
-        CPPUNIT_ASSERT_THROW(attrSetD.copyAttributeValues(0, attrSetA, 0), openvdb::LookupError);
-    }
-
     { // attribute insertion
         AttributeSet attrSetB(attrSetA);
 


### PR DESCRIPTION
There is currently no way to access this method via the PointDataLeafNode, because it only exposes a const AttributeSet. We also realised that similar functionality can be implemented externally if we provide access to the underlying AttributeArray (to be addressed in a future pull request).