### PR TITLE
Added typeless hasAttribute to PointDataLeafNode, renaming hasAttribute<T> to hasTypedAttribute<T>

### DIFF
--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -299,6 +299,22 @@ public:
     /// @brief Returns whether an attribute exists. This method is faster
     /// than hasAttribute(const Name&) as it avoids a map lookup.
     /// @param pos    Index of the attribute
+    bool hasAttribute(const size_t pos) const
+    {
+        return pos < mAttributeSet->size();
+    }
+
+    /// @brief Returns whether an attribute exists.
+    /// @param attributeName    Name of the attribute
+    bool hasAttribute(const Name& attributeName) const
+    {
+        const size_t pos = mAttributeSet->find(attributeName);
+        return pos != AttributeSet::INVALID_POS;
+    }
+
+    /// @brief Returns whether an attribute exists. This method is faster
+    /// than hasAttribute(const Name&) as it avoids a map lookup.
+    /// @param pos    Index of the attribute
     template <typename TypedAttributeArrayType>
     bool hasAttribute(const size_t pos) const
     {

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -313,10 +313,10 @@ public:
     }
 
     /// @brief Returns whether an attribute exists. This method is faster
-    /// than hasAttribute(const Name&) as it avoids a map lookup.
+    /// than hasTypedAttribute(const Name&) as it avoids a map lookup.
     /// @param pos    Index of the attribute
     template <typename TypedAttributeArrayType>
-    bool hasAttribute(const size_t pos) const
+    bool hasTypedAttribute(const size_t pos) const
     {
         if (pos >= mAttributeSet->size())     return false;
 
@@ -328,13 +328,13 @@ public:
     /// @brief Returns whether an attribute exists.
     /// @param attributeName    Name of the attribute
     template <typename TypedAttributeArrayType>
-    bool hasAttribute(const Name& attributeName) const
+    bool hasTypedAttribute(const Name& attributeName) const
     {
         const size_t pos = mAttributeSet->find(attributeName);
 
         if (pos == AttributeSet::INVALID_POS)   return false;
 
-        return hasAttribute<TypedAttributeArrayType>(pos);
+        return hasTypedAttribute<TypedAttributeArrayType>(pos);
     }
 
     /// @brief Append an attribute to the leaf.

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -524,26 +524,26 @@ TestPointDataLeaf::testAttributes()
     CPPUNIT_ASSERT_EQUAL(array0->size(), size_t(1));
     CPPUNIT_ASSERT_EQUAL(array1->size(), size_t(1));
 
-    // test leaf returns expected result for hasAttribute()
+    // test leaf returns expected result for hasAttribute() and hasTypedAttribute<T>()
 
     CPPUNIT_ASSERT(leaf.hasAttribute(/*pos*/0));
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>(/*pos=*/0));
-    CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeI>(/*pos=*/0));
+    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeS>(/*pos=*/0));
+    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeI>(/*pos=*/0));
     CPPUNIT_ASSERT(leaf.hasAttribute("density"));
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>("density"));
-    CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeI>("density"));
+    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeS>("density"));
+    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeI>("density"));
 
     CPPUNIT_ASSERT(leaf.hasAttribute(/*pos*/1));
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>(/*pos=*/1));
-    CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>(/*pos=*/1));
+    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeI>(/*pos=*/1));
+    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>(/*pos=*/1));
     CPPUNIT_ASSERT(leaf.hasAttribute("id"));
-    CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>("id"));
-    CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>("id"));
+    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeI>("id"));
+    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>("id"));
 
     CPPUNIT_ASSERT(!leaf.hasAttribute(/*pos*/2));
-    CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>(/*pos=*/2));
+    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>(/*pos=*/2));
     CPPUNIT_ASSERT(!leaf.hasAttribute("test"));
-    CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>("test"));
+    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>("test"));
 
     // test leaf can be successfully cast to TypedAttributeArray and check types
 

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -526,17 +526,23 @@ TestPointDataLeaf::testAttributes()
 
     // test leaf returns expected result for hasAttribute()
 
+    CPPUNIT_ASSERT(leaf.hasAttribute(/*pos*/0));
     CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>(/*pos=*/0));
     CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeI>(/*pos=*/0));
+    CPPUNIT_ASSERT(leaf.hasAttribute("density"));
     CPPUNIT_ASSERT(leaf.hasAttribute<AttributeS>("density"));
     CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeI>("density"));
 
+    CPPUNIT_ASSERT(leaf.hasAttribute(/*pos*/1));
     CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>(/*pos=*/1));
     CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>(/*pos=*/1));
+    CPPUNIT_ASSERT(leaf.hasAttribute("id"));
     CPPUNIT_ASSERT(leaf.hasAttribute<AttributeI>("id"));
     CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>("id"));
 
+    CPPUNIT_ASSERT(!leaf.hasAttribute(/*pos*/2));
     CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>(/*pos=*/2));
+    CPPUNIT_ASSERT(!leaf.hasAttribute("test"));
     CPPUNIT_ASSERT(!leaf.hasAttribute<AttributeS>("test"));
 
     // test leaf can be successfully cast to TypedAttributeArray and check types


### PR DESCRIPTION
This allows us to determine whether the given attribute array (either by name or index) exists in a PointDataLeafNode's underlying AttributeSet, without having to know up-front the value type and codec of that attribute array