### PR TITLE
Providing a typeless attributeArray accessor on PointDataLeafNode

### DIFF
--- a/openvdb_points/doc/examplecode.txt
+++ b/openvdb_points/doc/examplecode.txt
@@ -150,7 +150,8 @@ int main()
     }
 
     // Retrieve a write-able attribute handle for position
-    AttributeWriteHandle<openvdb::Vec3f>* attributeWriteHandle = leaf->attributeWriteHandle<openvdb::Vec3f>("P");
+    AttributeWriteHandle<openvdb::Vec3f>::Ptr attributeWriteHandle =
+        AttributeWriteHandle<openvdb::Vec3f>::create(leaf->attributeArray("P"));
 
     // Set the point positions to be at the center of each voxel (range is -0.5 -> 0.5)
     for (size_t i = 0; i < totalPoints; i++) {
@@ -166,7 +167,8 @@ int main()
     std::cout << "Testing random access:" << std::endl;
 
     // Retrieve a read-only attribute handle for position
-    AttributeHandle<openvdb::Vec3f>::Ptr attributeHandle = leaf->attributeHandle<openvdb::Vec3f>("P");
+    AttributeHandle<openvdb::Vec3f>::Ptr attributeHandle =
+        AttributeHandle<openvdb::Vec3f>::create(leaf->attributeArray("P"));
 
     // Create a co-ordinate to perform the look-up and voxel position in index space
     const openvdb::Coord ijk(4, 0, 0);
@@ -197,7 +199,8 @@ int main()
 
     // Now iterate over all points within all leaves
     for (PointDataTree::LeafCIter iter = grid->tree().cbeginLeaf(); iter; ++iter) {
-        AttributeHandle<openvdb::Vec3f>::Ptr attributeHandle = iter->attributeHandle<openvdb::Vec3f>("P");
+        AttributeHandle<openvdb::Vec3f>::Ptr attributeHandle =
+            AttributeHandle<openvdb::Vec3f>::create(iter->attributeArray("P"));
 
         for (size_t i = 0; i < totalPoints; i++) {
             /*point position = */ attributeHandle->get(i);

--- a/openvdb_points/tools/AttributeArray.h
+++ b/openvdb_points/tools/AttributeArray.h
@@ -318,6 +318,12 @@ public:
     /// Return a new attribute array of the given length @a n with uniform value zero.
     static Ptr create(size_t n);
 
+    /// Cast an AttributeArray to TypedAttributeArray<T>
+    static TypedAttributeArray& cast(AttributeArray& attributeArray);
+
+    /// Cast an AttributeArray to TypedAttributeArray<T>
+    static const TypedAttributeArray& cast(const AttributeArray& attributeArray);
+
     /// Return the name of this attribute's type (includes codec)
     static const NamePair& attributeType();
     /// Return the name of this attribute's type.
@@ -378,7 +384,6 @@ public:
     virtual void read(std::istream& is);
     /// Write attribute data to a stream.
     virtual void write(std::ostream& os) const;
-
 
 protected:
     virtual AccessorBasePtr getAccessor() const;
@@ -642,6 +647,21 @@ TypedAttributeArray<ValueType_, Codec_>::create(size_t n)
     return Ptr(new TypedAttributeArray(n));
 }
 
+template<typename ValueType_, typename Codec_>
+inline TypedAttributeArray<ValueType_, Codec_>&
+TypedAttributeArray<ValueType_, Codec_>::cast(AttributeArray& attributeArray)
+{
+    if (!attributeArray.isType<TypedAttributeArray>())     OPENVDB_THROW(TypeError, "Invalid Attribute Type");
+    return static_cast<TypedAttributeArray&>(attributeArray);
+}
+
+template<typename ValueType_, typename Codec_>
+inline const TypedAttributeArray<ValueType_, Codec_>&
+TypedAttributeArray<ValueType_, Codec_>::cast(const AttributeArray& attributeArray)
+{
+    if (!attributeArray.isType<TypedAttributeArray>())     OPENVDB_THROW(TypeError, "Invalid Attribute Type");
+    return static_cast<const TypedAttributeArray&>(attributeArray);
+}
 
 template<typename ValueType_, typename Codec_>
 AttributeArray::Ptr

--- a/openvdb_points/tools/PointConversion.h
+++ b/openvdb_points/tools/PointConversion.h
@@ -211,7 +211,7 @@ struct PopulatePositionAttributeOp {
             if (!pointIndexLeaf)    continue;
 
             typename AttributeWriteHandle<ValueType>::Ptr attributeWriteHandle =
-                leaf->template attributeWriteHandle<ValueType>("P");
+                AttributeWriteHandle<ValueType>::create(leaf->template attributeArray("P"));
 
             Index64 index = 0;
 
@@ -274,7 +274,7 @@ struct PopulateAttributeOp {
             if (!pointIndexLeaf)    continue;
 
             typename AttributeWriteHandle<ValueType>::Ptr attributeWriteHandle =
-                leaf->template attributeWriteHandle<ValueType>(mAttributeName);
+                AttributeWriteHandle<ValueType>::create(leaf->attributeArray(mAttributeName));
 
             Index64 index = 0;
 

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -360,100 +360,30 @@ public:
         mAttributeSet->reorderAttributes(replacement);
     }
 
-    template <typename AttributeType>
-    typename AttributeWriteHandle<AttributeType>::Ptr attributeWriteHandle(const size_t pos)
+    AttributeArray& attributeArray(const size_t pos)
     {
         if (pos >= mAttributeSet->size())             OPENVDB_THROW(LookupError, "Attribute Out Of Range");
-
-        AttributeArray* array = mAttributeSet->get(pos);
-
-        return AttributeWriteHandle<AttributeType>::create(*array);
+        return *mAttributeSet->get(pos);
     }
 
-    template <typename AttributeType>
-    typename AttributeWriteHandle<AttributeType>::Ptr attributeWriteHandle(const Name& attributeName)
+    AttributeArray& attributeArray(const Name& attributeName)
     {
         const size_t pos = mAttributeSet->find(attributeName);
-
         if (pos == AttributeSet::INVALID_POS)         OPENVDB_THROW(LookupError, "Attribute Not Found");
-
-        AttributeArray* array = mAttributeSet->get(pos);
-
-        return AttributeWriteHandle<AttributeType>::create(*array);
+        return *mAttributeSet->get(pos);
     }
 
-    template <typename AttributeType>
-    typename AttributeHandle<AttributeType>::Ptr attributeHandle(const size_t pos) const
+    const AttributeArray& attributeArray(const size_t pos) const
     {
         if (pos >= mAttributeSet->size())             OPENVDB_THROW(LookupError, "Attribute Out Of Range");
-
-        AttributeArray* array = mAttributeSet->get(pos);
-
-        return AttributeHandle<AttributeType>::create(*array);
+        return *mAttributeSet->get(pos);
     }
 
-    template <typename AttributeType>
-    typename AttributeHandle<AttributeType>::Ptr attributeHandle(const Name& attributeName) const
+    const AttributeArray& attributeArray(const Name& attributeName) const
     {
         const size_t pos = mAttributeSet->find(attributeName);
-
         if (pos == AttributeSet::INVALID_POS)         OPENVDB_THROW(LookupError, "Attribute Not Found");
-
-        AttributeArray* array = mAttributeSet->get(pos);
-
-        return AttributeHandle<AttributeType>::create(*array);
-    }
-
-    template <typename TypedAttributeType>
-    TypedAttributeType& typedAttributeArray(const size_t pos)
-    {
-        if (pos >= mAttributeSet->size())             OPENVDB_THROW(LookupError, "Attribute Out Of Range");
-
-        AttributeArray* array = mAttributeSet->get(pos);
-
-        if (!array->isType<TypedAttributeType>())     OPENVDB_THROW(LookupError, "Invalid Attribute Type");
-
-        return static_cast<TypedAttributeType& >(*array);
-    }
-
-    template <typename TypedAttributeType>
-    TypedAttributeType& typedAttributeArray(const Name& attributeName)
-    {
-        const size_t pos = mAttributeSet->find(attributeName);
-
-        if (pos == AttributeSet::INVALID_POS)         OPENVDB_THROW(LookupError, "Attribute Not Found");
-
-        AttributeArray* array = mAttributeSet->get(pos);
-
-        if (!array->isType<TypedAttributeType>())     OPENVDB_THROW(LookupError, "Invalid Attribute Type");
-
-        return static_cast<TypedAttributeType& >(*array);
-    }
-
-    template <typename TypedAttributeType>
-    const TypedAttributeType& typedAttributeArray(const size_t pos) const
-    {
-        if (pos >= mAttributeSet->size())             OPENVDB_THROW(LookupError, "Attribute Out Of Range");
-
-        const AttributeArray* array = mAttributeSet->getConst(pos);
-
-        if (!array->isType<TypedAttributeType>())     OPENVDB_THROW(LookupError, "Invalid Attribute Type");
-
-        return static_cast<const TypedAttributeType& >(*array);
-    }
-
-    template <typename TypedAttributeType>
-    const TypedAttributeType& typedAttributeArray(const Name& attributeName) const
-    {
-        const size_t pos = mAttributeSet->find(attributeName);
-
-        if (pos == AttributeSet::INVALID_POS)         OPENVDB_THROW(LookupError, "Attribute Not Found");
-
-        const AttributeArray* array = mAttributeSet->getConst(pos);
-
-        if (!array->isType<TypedAttributeType>())     OPENVDB_THROW(LookupError, "Invalid Attribute Type");
-
-        return static_cast<const TypedAttributeType& >(*array);
+        return *mAttributeSet->get(pos);
     }
 
     ValueTypePair pointIndex(const unsigned index) const

--- a/openvdb_points/unittest/TestAttributeArray.cc
+++ b/openvdb_points/unittest/TestAttributeArray.cc
@@ -293,6 +293,19 @@ TestAttributeArray::testAttributeArray()
     openvdb::tools::AttributeArray::Ptr attr =
         openvdb::tools::AttributeArray::create(
             AttributeArrayI::attributeType(), 34);
+
+    { // Casting
+        using namespace openvdb;
+        using namespace openvdb::tools;
+
+        AttributeArray::Ptr array = TypedAttributeArray<float>::create(0);
+        CPPUNIT_ASSERT_NO_THROW(TypedAttributeArray<float>::cast(*array));
+        CPPUNIT_ASSERT_THROW(TypedAttributeArray<int>::cast(*array), TypeError);
+
+        AttributeArray::ConstPtr constArray = array;
+        CPPUNIT_ASSERT_NO_THROW(TypedAttributeArray<float>::cast(*constArray));
+        CPPUNIT_ASSERT_THROW(TypedAttributeArray<int>::cast(*constArray), TypeError);
+    }
 }
 
 

--- a/openvdb_points/unittest/TestPointConversion.cc
+++ b/openvdb_points/unittest/TestPointConversion.cc
@@ -298,8 +298,8 @@ TestPointConversion::testPointConversion()
 
     for (; leafIter; ++leafIter) {
 
-        AttributeHandle<Vec3f>::Ptr posHandle = leafIter->attributeHandle<Vec3f>("P");
-        AttributeHandle<int32_t>::Ptr idHandle = leafIter->attributeHandle<int32_t>("id");
+        AttributeHandle<Vec3f>::Ptr posHandle = AttributeHandle<Vec3f>::create(leafIter->attributeArray("P"));
+        AttributeHandle<int32_t>::Ptr idHandle = AttributeHandle<int32_t>::create(leafIter->attributeArray("id"));
 
         for (PointDataTree::LeafNodeType::ValueOnCIter valueIter = leafIter->cbeginValueOn(); valueIter; ++valueIter) {
 

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -545,43 +545,54 @@ TestPointDataLeaf::testAttributes()
     CPPUNIT_ASSERT(!leaf.hasAttribute("test"));
     CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>("test"));
 
-    // test leaf can be successfully cast to TypedAttributeArray and check types
-
-    CPPUNIT_ASSERT(matchingNamePairs(leaf.typedAttributeArray<AttributeS>(/*pos=*/0).type(),
-                         AttributeS::attributeType()));
-    CPPUNIT_ASSERT(matchingNamePairs(leaf.typedAttributeArray<AttributeS>("density").type(),
-                         AttributeS::attributeType()));
-    CPPUNIT_ASSERT(matchingNamePairs(leaf.typedAttributeArray<AttributeI>(/*pos=*/1).type(),
-                         AttributeI::attributeType()));
-    CPPUNIT_ASSERT(matchingNamePairs(leaf.typedAttributeArray<AttributeI>("id").type(),
-                         AttributeI::attributeType()));
-
+    // test underlying attributeArray can be accessed by name and index, and that their types are as expected.
     const LeafType* constLeaf = &leaf;
 
-    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->typedAttributeArray<AttributeS>(/*pos=*/0).type(),
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray(/*pos*/0).type(), AttributeS::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray("density").type(), AttributeS::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray(/*pos*/1).type(), AttributeI::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray("id").type(), AttributeI::attributeType()));
+
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray(/*pos*/0).type(), AttributeS::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray("density").type(), AttributeS::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray(/*pos*/1).type(), AttributeI::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray("id").type(), AttributeI::attributeType()));
+
+    // check invalid pos or name throws
+
+    CPPUNIT_ASSERT_THROW(leaf.attributeArray(/*pos=*/3), openvdb::LookupError);
+    CPPUNIT_ASSERT_THROW(leaf.attributeArray("not_there"), openvdb::LookupError);
+
+    CPPUNIT_ASSERT_THROW(constLeaf->attributeArray(/*pos=*/3), openvdb::LookupError);
+    CPPUNIT_ASSERT_THROW(constLeaf->attributeArray("not_there"), openvdb::LookupError);
+
+    // test leaf can be successfully cast to TypedAttributeArray and check types
+
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray(/*pos=*/0).type(),
                          AttributeS::attributeType()));
-    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->typedAttributeArray<AttributeS>("density").type(),
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray("density").type(),
                          AttributeS::attributeType()));
-    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->typedAttributeArray<AttributeI>(/*pos=*/1).type(),
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray(/*pos=*/1).type(),
                          AttributeI::attributeType()));
-    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->typedAttributeArray<AttributeI>("id").type(),
+    CPPUNIT_ASSERT(matchingNamePairs(leaf.attributeArray("id").type(),
                          AttributeI::attributeType()));
 
-    // check invalid type, pos or name throws
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray(/*pos=*/0).type(),
+                         AttributeS::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray("density").type(),
+                         AttributeS::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray(/*pos=*/1).type(),
+                         AttributeI::attributeType()));
+    CPPUNIT_ASSERT(matchingNamePairs(constLeaf->attributeArray("id").type(),
+                         AttributeI::attributeType()));
 
-    CPPUNIT_ASSERT_THROW(leaf.typedAttributeArray<AttributeI>(/*pos=*/0), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(leaf.typedAttributeArray<AttributeI>("density"), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(leaf.typedAttributeArray<AttributeS>(/*pos=*/1), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(leaf.typedAttributeArray<AttributeS>("id"), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(leaf.typedAttributeArray<AttributeS>(/*pos=*/2), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(leaf.typedAttributeArray<AttributeS>("test"), openvdb::LookupError);
+    // check invalid pos or name throws
 
-    CPPUNIT_ASSERT_THROW(constLeaf->typedAttributeArray<AttributeI>(/*pos=*/0), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(constLeaf->typedAttributeArray<AttributeI>("density"), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(constLeaf->typedAttributeArray<AttributeS>(/*pos=*/1), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(constLeaf->typedAttributeArray<AttributeS>("id"), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(constLeaf->typedAttributeArray<AttributeS>(/*pos=*/2), openvdb::LookupError);
-    CPPUNIT_ASSERT_THROW(constLeaf->typedAttributeArray<AttributeS>("test"), openvdb::LookupError);
+    CPPUNIT_ASSERT_THROW(leaf.attributeArray(/*pos=*/2), openvdb::LookupError);
+    CPPUNIT_ASSERT_THROW(leaf.attributeArray("test"), openvdb::LookupError);
+
+    CPPUNIT_ASSERT_THROW(constLeaf->attributeArray(/*pos=*/2), openvdb::LookupError);
+    CPPUNIT_ASSERT_THROW(constLeaf->attributeArray("test"), openvdb::LookupError);
 
     // check memory usage = attribute set + base leaf
 
@@ -712,7 +723,7 @@ TestPointDataLeaf::testEquivalence()
 
     // manually change some values in the density array
 
-    TypedAttributeArray<float>& attr = leaf.typedAttributeArray<AttributeS>("density");
+    TypedAttributeArray<float>& attr = TypedAttributeArray<float>::cast(leaf.attributeArray("density"));
 
     attr.set(0, 5.0f);
     attr.set(50, 2.0f);
@@ -790,7 +801,7 @@ TestPointDataLeaf::testIO()
 
     // manually change some values in the density array
 
-    TypedAttributeArray<float>& attr = leaf.typedAttributeArray<AttributeS>("density");
+    TypedAttributeArray<float>& attr = TypedAttributeArray<float>::cast(leaf.attributeArray("density"));
 
     attr.set(0, 5.0f);
     attr.set(50, 2.0f);

--- a/openvdb_points_clarisse/clarisse/module/GeometryProperty_OpenVDBPoints.cc
+++ b/openvdb_points_clarisse/clarisse/module/GeometryProperty_OpenVDBPoints.cc
@@ -126,7 +126,7 @@ GeometryProperty_OpenVDBPoints::extract_value_float(const GeometryProperty& prop
 
     if (!leaf)  return 0;
 
-    const typename AttributeHandle<ValueType>::Ptr attributeHandle = leaf->attributeHandle<ValueType>(prop.name());
+    const typename AttributeHandle<ValueType>::Ptr attributeHandle = AttributeHandle<ValueType>::create(leaf->attributeArray(prop.name()));
 
     const ValueType& value = attributeHandle->get(Index64(sub_primitive_id));
 

--- a/openvdb_points_clarisse/clarisse/module/Module_OpenVDB_Points.cc
+++ b/openvdb_points_clarisse/clarisse/module/Module_OpenVDB_Points.cc
@@ -489,7 +489,8 @@ namespace resource
 
         for (PointDataTree::LeafCIter leaf = tree.cbeginLeaf(); leaf; ++leaf)
         {
-            const openvdb::tools::AttributeHandle<openvdb::Vec3f>::Ptr positionHandle = leaf->attributeHandle<openvdb::Vec3f>("P");
+            const openvdb::tools::AttributeHandle<openvdb::Vec3f>::Ptr positionHandle =
+                openvdb::tools::AttributeHandle<openvdb::Vec3f>::create(leaf->attributeArray("P"));
 
             for (PointDataTree::LeafNodeType::ValueOnCIter value = leaf->cbeginValueOn(); value; ++value)
             {
@@ -536,7 +537,7 @@ namespace resource
 
         // load the velocities
 
-        if (tree.cbeginLeaf()->hasAttribute<openvdb::tools::TypedAttributeArray<openvdb::Vec3f> >("v"))
+        if (tree.cbeginLeaf()->hasAttribute("v"))
         {
             AppProgressBar* velocity_progress_bar = object.get_application().create_progress_bar(CoreString("Loading Velocities into Point Cloud"));
 
@@ -544,7 +545,8 @@ namespace resource
 
             for (PointDataTree::LeafCIter leaf = tree.cbeginLeaf(); leaf; ++leaf)
             {
-                const openvdb::tools::AttributeHandle<openvdb::Vec3f>::Ptr velocityHandle = leaf->attributeHandle<openvdb::Vec3f>("v");
+                const openvdb::tools::AttributeHandle<openvdb::Vec3f>::Ptr velocityHandle =
+                    openvdb::tools::AttributeHandle<openvdb::Vec3f>::create(leaf->attributeArray("v"));
 
                 for (PointDataTree::LeafNodeType::ValueOnCIter value = leaf->cbeginValueOn(); value; ++value)
                 {

--- a/openvdb_points_clarisse/clarisse/module/ResourceData_OpenVDBPoints.cc
+++ b/openvdb_points_clarisse/clarisse/module/ResourceData_OpenVDBPoints.cc
@@ -101,7 +101,7 @@ struct ConvertVelocityToIndexSpaceOp {
         for (LeafManager::LeafRange::Iterator leaf=range.begin(); leaf; ++leaf) {
 
             typename AttributeWriteHandle<VelocityType>::Ptr velocityWriteHandle =
-                leaf->attributeWriteHandle<VelocityType>(mIndex);
+                AttributeWriteHandle<VelocityType>::create(leaf->attributeArray(mIndex));
 
             // @todo: need to extend the AttributeWriteHandle API to support uniform values
 
@@ -159,7 +159,7 @@ struct ConvertScalarToIndexSpaceOp {
         for (LeafManagerT::LeafRange::Iterator leaf=range.begin(); leaf; ++leaf) {
 
             typename AttributeWriteHandle<ScalarType>::Ptr scalarWriteHandle =
-                leaf->attributeWriteHandle<ScalarType>(mIndex);
+                AttributeWriteHandle<ScalarType>::create(leaf->attributeArray(mIndex));
 
             // @todo: need to extend the AttributeWriteHandle API to support uniform values
 
@@ -230,10 +230,9 @@ void localise(PointDataGrid::Ptr& grid)
 
     // localise velocity
 
-    const size_t velocityIndex = descriptor.find("v");
-
-    if (velocityIndex != AttributeSet::INVALID_POS)
+    if (iter->hasAttribute("v"))
     {
+        const size_t velocityIndex = descriptor.find("v");
         const NamePair& type = descriptor.type(velocityIndex);
 
         if (type.first == "vec3s") {
@@ -249,10 +248,9 @@ void localise(PointDataGrid::Ptr& grid)
 
     // localise radius
 
-    const size_t pscaleIndex = descriptor.find("pscale");
-
-    if (pscaleIndex != AttributeSet::INVALID_POS)
+    if (iter->hasAttribute("pscale"))
     {
+        const size_t pscaleIndex = descriptor.find("pscale");
         const NamePair& type = descriptor.type(pscaleIndex);
 
         if (type.first == "float") {

--- a/openvdb_points_houdini/houdini/GR_PrimVDBPoints.cc
+++ b/openvdb_points_houdini/houdini/GR_PrimVDBPoints.cc
@@ -278,7 +278,8 @@ struct FillGPUBuffersPosition {
             const openvdb::Index64 leafOffset = mLeafOffsets[n].second;
 
             typename openvdb::tools::AttributeHandle<AttributeType>::Ptr handle =
-                            leaf->template attributeHandle<AttributeType>(mAttributeIndex);
+                openvdb::tools::AttributeHandle<AttributeType>::create(
+                    leaf->template attributeArray(mAttributeIndex));
 
             openvdb::Index64 offset = 0;
 
@@ -350,7 +351,8 @@ struct FillGPUBuffersColor {
             const openvdb::Index64 leafOffset = mLeafOffsets[n].second;
 
             typename openvdb::tools::AttributeHandle<AttributeType>::Ptr handle =
-                            leaf->template attributeHandle<AttributeType>(mAttributeIndex);
+                openvdb::tools::AttributeHandle<AttributeType>::create(
+                    leaf->template attributeArray(mAttributeIndex));
 
             openvdb::Index64 offset = 0;
 

--- a/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
+++ b/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
@@ -438,7 +438,7 @@ struct ConvertPointDataGridPositionOp {
             const PointDataLeaf& leaf = leafOffset.first;
             GA_Offset offset = leafOffset.second;
 
-            AttributeHandle<Vec3f>::Ptr handle = leaf.template attributeHandle<Vec3f>(mIndex);
+            AttributeHandle<Vec3f>::Ptr handle = AttributeHandle<Vec3f>::create(leaf.template attributeArray(mIndex));
 
             for (PointDataTree::LeafNodeType::ValueOnCIter iter = leaf.cbeginValueOn(); iter; ++iter) {
 
@@ -528,7 +528,8 @@ struct ConvertPointDataGridAttributeOp {
             const PointDataLeaf& leaf = leafOffset.first;
             GA_Offset offset = leafOffset.second;
 
-            typename AttributeHandle<AttributeType>::Ptr handle = leaf.template attributeHandle<AttributeType>(mIndex);
+            typename AttributeHandle<AttributeType>::Ptr handle =
+                AttributeHandle<AttributeType>::create(leaf.template attributeArray(mIndex));
 
             for (PointDataTree::LeafNodeType::ValueOnCIter iter = leaf.cbeginValueOn(); iter; ++iter) {
 


### PR DESCRIPTION
This allows us to obtain a reference to a ```PointDataLeafNode```'s underlying ```AttributeArray``` object, given its name or index, without having to know its value type and codec.

In a bid to keep the API as simple as possible, we have removed all other accessors from PointDataLeafNode (typedAttributeArray, attributeHandle, and attributeWriteHandle).

We provide a ```TypedAttributeArray<T>::cast``` method for down-casting. ```AttributeHandle<T>``` and ```AttributeWriteHandle<T>``` can already be constructed from an AttributeArray reference.