### PR TITLE
Has value type

### DIFF
--- a/openvdb_points/tools/AttributeArray.h
+++ b/openvdb_points/tools/AttributeArray.h
@@ -196,6 +196,10 @@ public:
     template<typename AttributeArrayType>
     bool isType() const { return this->type() == AttributeArrayType::attributeType(); }
 
+    /// Return @c true if this attribute has a value type the same as the template parameter
+    template<typename ValueType>
+    bool hasValueType() const { return this->type().first == typeNameAsString<ValueType>();}
+
     /// Set value at given index @a n from @a sourceIndex of another @a sourceArray
     virtual void set(const Index n, const AttributeArray& sourceArray, const Index sourceIndex) = 0;
 

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -310,31 +310,6 @@ public:
         return pos != AttributeSet::INVALID_POS;
     }
 
-    /// @brief Returns whether an attribute exists. This method is faster
-    /// than hasTypedAttribute(const Name&) as it avoids a map lookup.
-    /// @param pos    Index of the attribute
-    template <typename TypedAttributeArrayType>
-    bool hasTypedAttribute(const size_t pos) const
-    {
-        if (pos >= mAttributeSet->size())     return false;
-
-        const AttributeArray* array = mAttributeSet->getConst(pos);
-
-        return array->isType<TypedAttributeArrayType>();
-    }
-
-    /// @brief Returns whether an attribute exists.
-    /// @param attributeName    Name of the attribute
-    template <typename TypedAttributeArrayType>
-    bool hasTypedAttribute(const Name& attributeName) const
-    {
-        const size_t pos = mAttributeSet->find(attributeName);
-
-        if (pos == AttributeSet::INVALID_POS)   return false;
-
-        return hasTypedAttribute<TypedAttributeArrayType>(pos);
-    }
-
     /// @brief Append an attribute to the leaf.
     void appendAttribute(const AttributeSet::Util::NameAndType& attribute,
                          const Descriptor& expected, Descriptor::Ptr& replacement)

--- a/openvdb_points/unittest/TestAttributeArray.cc
+++ b/openvdb_points/unittest/TestAttributeArray.cc
@@ -107,6 +107,7 @@ TestAttributeArray::testFixedPointConversion()
 void
 TestAttributeArray::testAttributeArray()
 {
+    typedef openvdb::tools::TypedAttributeArray<float> AttributeArrayF;
     typedef openvdb::tools::TypedAttributeArray<double> AttributeArrayD;
 
     {
@@ -132,6 +133,20 @@ TestAttributeArray::testAttributeArray()
 
     typedef openvdb::tools::FixedPointAttributeCodec<uint16_t> FixedPointCodec;
     typedef openvdb::tools::TypedAttributeArray<double, FixedPointCodec> AttributeArrayC;
+
+    { // test hasValueType()
+        openvdb::tools::AttributeArray::Ptr attrC(new AttributeArrayC(50));
+        openvdb::tools::AttributeArray::Ptr attrD(new AttributeArrayD(50));
+        openvdb::tools::AttributeArray::Ptr attrF(new AttributeArrayF(50));
+
+        CPPUNIT_ASSERT(attrD->hasValueType<double>());
+        CPPUNIT_ASSERT(attrC->hasValueType<double>());
+        CPPUNIT_ASSERT(!attrF->hasValueType<double>());
+
+        CPPUNIT_ASSERT(!attrD->hasValueType<float>());
+        CPPUNIT_ASSERT(!attrC->hasValueType<float>());
+        CPPUNIT_ASSERT(attrF->hasValueType<float>());
+    }
 
     {
         openvdb::tools::AttributeArray::Ptr attr(new AttributeArrayC(50));

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -677,27 +677,16 @@ TestPointDataLeaf::testAttributes()
 
     CPPUNIT_ASSERT_EQUAL(array0->size(), size_t(1));
     CPPUNIT_ASSERT_EQUAL(array1->size(), size_t(1));
-
-    // test leaf returns expected result for hasAttribute() and hasTypedAttribute<T>()
+    // test leaf returns expected result for hasAttribute()
 
     CPPUNIT_ASSERT(leaf.hasAttribute(/*pos*/0));
-    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeS>(/*pos=*/0));
-    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeI>(/*pos=*/0));
     CPPUNIT_ASSERT(leaf.hasAttribute("density"));
-    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeS>("density"));
-    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeI>("density"));
 
     CPPUNIT_ASSERT(leaf.hasAttribute(/*pos*/1));
-    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeI>(/*pos=*/1));
-    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>(/*pos=*/1));
     CPPUNIT_ASSERT(leaf.hasAttribute("id"));
-    CPPUNIT_ASSERT(leaf.hasTypedAttribute<AttributeI>("id"));
-    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>("id"));
 
     CPPUNIT_ASSERT(!leaf.hasAttribute(/*pos*/2));
-    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>(/*pos=*/2));
     CPPUNIT_ASSERT(!leaf.hasAttribute("test"));
-    CPPUNIT_ASSERT(!leaf.hasTypedAttribute<AttributeS>("test"));
 
     // test underlying attributeArray can be accessed by name and index, and that their types are as expected.
     const LeafType* constLeaf = &leaf;


### PR DESCRIPTION
As requested (@jbrd), tidying up this part of the API. Removing hasTypedAttribute(), this is less confusing now that identical functionality is available through the AttributeArray API. 

Also, added a hasValueType() method to the AttributeArray to allow for cases where you wish to use an AttributeHandle and don't care about the Codec.