### PR TITLE
Descriptor Fixes

### DIFF
--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -863,8 +863,8 @@ AttributeSet::Descriptor::appendTo(NameAndTypeVec& attrs) const
 bool
 AttributeSet::Descriptor::hasGroup(const Name& group) const
 {
-    if (group.empty()) {
-        OPENVDB_THROW(KeyError, "Cannot use an empty group name as a key.");
+    if (!validGroupName(group)) {
+        OPENVDB_THROW(KeyError, ("Invalid group name - " + group).c_str());
     }
 
     return mGroupMap.find(group) != mGroupMap.end();
@@ -873,8 +873,8 @@ AttributeSet::Descriptor::hasGroup(const Name& group) const
 void
 AttributeSet::Descriptor::setGroup(const Name& group, const size_t offset)
 {
-    if (group.empty()) {
-        OPENVDB_THROW(KeyError, "Cannot use an empty group name as a key.");
+    if (!validGroupName(group)) {
+        OPENVDB_THROW(KeyError, ("Invalid group name - " + group).c_str());
     }
 
     mGroupMap[group] = offset;
@@ -883,8 +883,8 @@ AttributeSet::Descriptor::setGroup(const Name& group, const size_t offset)
 void
 AttributeSet::Descriptor::dropGroup(const Name& group)
 {
-    if (group.empty()) {
-        OPENVDB_THROW(KeyError, "Cannot use an empty group name as a key.");
+    if (!validGroupName(group)) {
+        OPENVDB_THROW(KeyError, ("Invalid group name - " + group).c_str());
     }
 
     mGroupMap.erase(group);

--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -515,6 +515,7 @@ AttributeSet::operator==(const AttributeSet& other) const {
 AttributeSet::Descriptor::Descriptor()
     : mNameMap()
     , mTypes()
+    , mGroupMap()
     , mMetadata()
 {
 }
@@ -523,6 +524,7 @@ AttributeSet::Descriptor::Descriptor()
 AttributeSet::Descriptor::Descriptor(const Descriptor& rhs)
     : mNameMap(rhs.mNameMap)
     , mTypes(rhs.mTypes)
+    , mGroupMap(rhs.mGroupMap)
     , mMetadata(rhs.mMetadata)
 {
 }
@@ -534,7 +536,8 @@ AttributeSet::Descriptor::operator==(const Descriptor& rhs) const
     if (this == &rhs) return true;
 
     if (mTypes.size()   != rhs.mTypes.size() ||
-        mNameMap.size() != rhs.mNameMap.size()) {
+        mNameMap.size() != rhs.mNameMap.size() ||
+        mGroupMap.size() != rhs.mGroupMap.size()) {
         return false;
     }
 
@@ -544,7 +547,8 @@ AttributeSet::Descriptor::operator==(const Descriptor& rhs) const
 
     if (this->mMetadata != rhs.mMetadata)  return false;
 
-    return std::equal(mNameMap.begin(), mNameMap.end(), rhs.mNameMap.begin());
+    return  std::equal(mGroupMap.begin(), mGroupMap.end(), rhs.mGroupMap.begin()) &&
+            std::equal(mNameMap.begin(), mNameMap.end(), rhs.mNameMap.begin());
 }
 
 
@@ -554,7 +558,8 @@ AttributeSet::Descriptor::hasSameAttributes(const Descriptor& rhs) const
     if (this == &rhs) return true;
 
     if (mTypes.size()   != rhs.mTypes.size() ||
-        mNameMap.size() != rhs.mNameMap.size()) {
+        mNameMap.size() != rhs.mNameMap.size() ||
+        mGroupMap.size() != rhs.mGroupMap.size()) {
         return false;
     }
 
@@ -567,7 +572,7 @@ AttributeSet::Descriptor::hasSameAttributes(const Descriptor& rhs) const
         if (mTypes[it->second] != rhs.mTypes[index]) return false;
     }
 
-    return true;
+    return std::equal(mGroupMap.begin(), mGroupMap.end(), rhs.mGroupMap.begin());
 }
 
 

--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -389,8 +389,25 @@ AttributeSet::dropAttributes(   const std::vector<size_t>& pos,
 
 
 void
+AttributeSet::renameAttributes(const Descriptor& expected, const DescriptorPtr& replacement)
+{
+    // ensure the descriptor is as expected
+    if (*mDescr != expected) {
+        OPENVDB_THROW(LookupError, "Cannot rename attribute as descriptors do not match.")
+    }
+
+    mDescr = replacement;
+}
+
+
+void
 AttributeSet::reorderAttributes(const DescriptorPtr& replacement)
 {
+    if (*mDescr == *replacement) {
+        this->resetDescriptor(replacement);
+        return;
+    }
+
     if (!mDescr->hasSameAttributes(*replacement)) {
         OPENVDB_THROW(LookupError, "Cannot reorder attributes as descriptors do not contain the same attributes.")
     }
@@ -411,11 +428,11 @@ AttributeSet::reorderAttributes(const DescriptorPtr& replacement)
 
 
 void
-AttributeSet::renameAttributes(const Descriptor& expected, DescriptorPtr& replacement)
+AttributeSet::resetDescriptor(const DescriptorPtr& replacement)
 {
-    // ensure the descriptor is as expected
-    if (*mDescr != expected) {
-        OPENVDB_THROW(LookupError, "Cannot rename attribute as descriptors do not match.")
+    // ensure the descriptors match
+    if (*mDescr != *replacement) {
+        OPENVDB_THROW(LookupError, "Cannot swap descriptor as replacement does not match.")
     }
 
     mDescr = replacement;

--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -46,6 +46,7 @@
 #include <boost/shared_ptr.hpp> // shared_ptr
 
 #include <vector>
+#include <cctype> // isalnum
 
 #include <openvdb_points/tools/AttributeArray.h>
 
@@ -355,6 +356,16 @@ public:
     /// Return a unique name for an attribute array based on given name
     const Name uniqueName(const Name& name) const;
 
+    /// Return true if the group name is valid
+    static bool validGroupName(const Name& name)
+    {
+        struct Internal {
+            static bool isNotAlnumUnderscore(int c) { return !(isalnum(c) || (c == '_')); }
+        };
+        if (name.empty())   return false;
+        return find_if(name.begin(), name.end(), Internal::isNotAlnumUnderscore) == name.end();
+    }
+
     /// Serialize this descriptor to the given stream.
     void write(std::ostream&) const;
     /// Unserialize this transform from the given stream.
@@ -362,6 +373,7 @@ public:
 
 private:
     size_t insert(const std::string& name, const NamePair& typeName);
+
     NameToPosMap                mNameMap;
     std::vector<NamePair>       mTypes;
     NameToPosMap                mGroupMap;

--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -200,13 +200,17 @@ public:
     void dropAttributes(const std::vector<size_t>& pos,
                         const Descriptor& expected, DescriptorPtr& replacement);
 
+    /// Re-name attributes in set to match a provided descriptor
+    /// Replaces own descriptor with @a replacement
+    void renameAttributes(const Descriptor& expected, const DescriptorPtr& replacement);
+
     /// Re order attribute set to match a provided descriptor
     /// Replaces own descriptor with @a replacement
     void reorderAttributes(const DescriptorPtr& replacement);
 
-    /// Re-name attributes in set to match a provided descriptor
-    /// Replaces own descriptor with @a replacement
-    void renameAttributes(const Descriptor& expected, DescriptorPtr& replacement);
+    /// Swap current descriptor with a @a replacement
+    /// Note the provided Descriptor must be identical to the replacement
+    void resetDescriptor(const DescriptorPtr& replacement);
 
     /// Read the entire set from a stream.
     void read(std::istream&);

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -83,6 +83,16 @@ typedef tree::Tree<tree::RootNode<tree::InternalNode<tree::InternalNode
 typedef Grid<PointDataTree> PointDataGrid;
 
 
+/// @brief  Deep copy the descriptor across all leaf nodes.
+///
+/// @param  tree the PointDataTree.
+///
+/// @note This method will fail if the Descriptors in the tree are not all identical.
+template <typename PointDataTreeT>
+inline void
+makeDescriptorUnique(PointDataTreeT& tree);
+
+
 ////////////////////////////////////////
 
 // Internal utility methods
@@ -223,6 +233,10 @@ public:
     /// This leaf will assume ownership of the given attribute set. The descriptors must
     /// match and the voxel offsets values will need updating if the point order is different.
     void swap(AttributeSet* attributeSet);
+
+    /// @brief Replace the descriptor with a new one
+    /// The new Descriptor must exactly match the old one
+    void resetDescriptor(const Descriptor::Ptr& replacement);
 
     /// @brief Sets all of the voxel offset values on this leaf, from the given vector
     /// of @a offsets. If @a updateValueMask is true, then the active value mask will
@@ -617,6 +631,13 @@ PointDataLeafNode<T, Log2Dim>::swap(AttributeSet* attributeSet)
 
 template<typename T, Index Log2Dim>
 inline void
+PointDataLeafNode<T, Log2Dim>::resetDescriptor(const Descriptor::Ptr& replacement)
+{
+    mAttributeSet->resetDescriptor(replacement);
+}
+
+template<typename T, Index Log2Dim>
+inline void
 PointDataLeafNode<T, Log2Dim>::setOffsets(const std::vector<ValueType>& offsets, const bool updateValueMask)
 {
     if (offsets.size() != LeafNodeType::NUM_VALUES) {
@@ -894,6 +915,25 @@ PointDataLeafNode<T, Log2Dim>::memUsage() const
 {
     return BaseLeaf::memUsage() + mAttributeSet->memUsage();
 }
+
+
+////////////////////////////////////////
+
+
+template <typename PointDataTreeT>
+inline void
+makeDescriptorUnique(PointDataTreeT& tree)
+{
+    typename PointDataTreeT::LeafIter leafIter = tree.beginLeaf();
+    if (!leafIter)  return;
+
+    const AttributeSet::Descriptor& descriptor = leafIter->attributeSet().descriptor();
+    AttributeSet::Descriptor::Ptr newDescriptor(new AttributeSet::Descriptor(descriptor));
+    for (; leafIter; ++leafIter) {
+        leafIter->resetDescriptor(newDescriptor);
+    }
+}
+
 
 } // namespace tools
 

--- a/openvdb_points/tools/PointGroup.h
+++ b/openvdb_points/tools/PointGroup.h
@@ -410,6 +410,12 @@ inline void appendGroup(PointDataTree& tree, const Name& group)
                                                 /*hidden=*/false, /*transient=*/false, /*group=*/true);
         tbb::parallel_for(typename tree::template LeafManager<PointDataTree>(tree).leafRange(), append);
     }
+    else {
+        // make the descriptor unique before we modify the group map
+
+        makeDescriptorUnique(tree);
+        descriptor = attributeSet.descriptorPtr();
+    }
 
     // ensure that there are now available groups
 
@@ -459,7 +465,13 @@ inline void dropGroup(PointDataTree& tree, const Name& group, const bool compact
     if (!iter)  return;
 
     const AttributeSet& attributeSet = iter->attributeSet();
+
+    // make the descriptor unique before we modify the group map
+
+    makeDescriptorUnique(tree);
     Descriptor::Ptr descriptor = attributeSet.descriptorPtr();
+
+    // now drop the group
 
     descriptor->dropGroup(group);
 
@@ -502,8 +514,12 @@ inline void dropGroups( PointDataTree& tree)
     if (!iter)  return;
 
     const AttributeSet& attributeSet = iter->attributeSet();
-    Descriptor::Ptr descriptor = attributeSet.descriptorPtr();
     GroupInfo groupInfo(attributeSet);
+
+    // make the descriptor unique before we modify the group map
+
+    makeDescriptorUnique(tree);
+    Descriptor::Ptr descriptor = attributeSet.descriptorPtr();
 
     descriptor->clearGroups();
 
@@ -535,12 +551,16 @@ inline void compactGroups(PointDataTree& tree)
     if (!iter)  return;
 
     const AttributeSet& attributeSet = iter->attributeSet();
-    Descriptor::Ptr descriptor = attributeSet.descriptorPtr();
     GroupInfo groupInfo(attributeSet);
 
     // early exit if not possible to compact
 
     if (!groupInfo.canCompactGroups())    return;
+
+    // make the descriptor unique before we modify the group map
+
+    makeDescriptorUnique(tree);
+    Descriptor::Ptr descriptor = attributeSet.descriptorPtr();
 
     // generate a list of group offsets and move them (one-by-one)
     // TODO: improve this algorithm to move multiple groups per array at once

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -259,14 +259,26 @@ TestAttributeSet::testAttributeSetDescriptor()
         CPPUNIT_ASSERT_EQUAL(uniqueName2, openvdb::Name("test2"));
     }
 
+    { // Test group name validity
+        CPPUNIT_ASSERT(!Descriptor::validGroupName(""));
+        CPPUNIT_ASSERT(Descriptor::validGroupName("test1"));
+        CPPUNIT_ASSERT(!Descriptor::validGroupName("test1!"));
+        CPPUNIT_ASSERT(Descriptor::validGroupName("abc_def"));
+        CPPUNIT_ASSERT(!Descriptor::validGroupName("abc=def"));
+    }
+
     { //  Test hasGroup(), setGroup(), dropGroup(), clearGroups()
         Descriptor descr;
 
-        // ensure all methods throw if an empty key is used
+        // ensure all methods throw if an empty or invalid key is used
 
         CPPUNIT_ASSERT_THROW(descr.hasGroup(""), openvdb::KeyError);
         CPPUNIT_ASSERT_THROW(descr.setGroup("", 0), openvdb::KeyError);
         CPPUNIT_ASSERT_THROW(descr.dropGroup(""), openvdb::KeyError);
+
+        CPPUNIT_ASSERT_THROW(descr.hasGroup("abc-"), openvdb::KeyError);
+        CPPUNIT_ASSERT_THROW(descr.setGroup("abc-", 0), openvdb::KeyError);
+        CPPUNIT_ASSERT_THROW(descr.dropGroup("abc-"), openvdb::KeyError);
 
         CPPUNIT_ASSERT(!descr.hasGroup("test1"));
 

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -191,6 +191,32 @@ TestAttributeSet::testAttributeSetDescriptor()
 
     CPPUNIT_ASSERT(*descrA == *descrB);
 
+    descrB->setGroup("test", size_t(0));
+    descrB->setGroup("test2", size_t(1));
+
+    Descriptor descrC(*descrB);
+
+    CPPUNIT_ASSERT(descrB->hasSameAttributes(descrC));
+    CPPUNIT_ASSERT(descrC.hasGroup("test"));
+    CPPUNIT_ASSERT(*descrB == descrC);
+
+    descrC.dropGroup("test");
+    descrC.dropGroup("test2");
+
+    CPPUNIT_ASSERT(!descrB->hasSameAttributes(descrC));
+    CPPUNIT_ASSERT(!descrC.hasGroup("test"));
+    CPPUNIT_ASSERT(*descrB != descrC);
+
+    descrC.setGroup("test2", size_t(1));
+    descrC.setGroup("test3", size_t(0));
+
+    CPPUNIT_ASSERT(!descrB->hasSameAttributes(descrC));
+
+    descrC.dropGroup("test3");
+    descrC.setGroup("test", size_t(0));
+
+    CPPUNIT_ASSERT(descrB->hasSameAttributes(descrC));
+
     // rebuild NameAndTypeVec
 
     Descriptor::NameAndTypeVec rebuildNames;


### PR DESCRIPTION
* Add in some missing group map comparisons to the Descriptor comparison methods.
* Make sure that group names can only contain alpha-numeric or underscore characters
* Add a makeDescriptorUnique(tree) method that makes sure a PointDataTree's Descriptor is not shared with another PointDataTree
* Fix an issue where operations that only modify the group map use makeDescriptorUnique() to deep-copy it first