### PR TITLE
Range Fixes

### DIFF
--- a/openvdb_points/tools/AttributeArray.h
+++ b/openvdb_points/tools/AttributeArray.h
@@ -907,6 +907,7 @@ TypedAttributeArray<ValueType_, Codec_>::getUnsafe(Index n) const
 {
     assert(!this->isCompressed());
     assert(!this->isOutOfCore());
+    assert(n < this->size());
 
     ValueType val;
     Codec::decode(/*in=*/mData[mIsUniform ? 0 : n], /*out=*/val);
@@ -920,6 +921,7 @@ TypedAttributeArray<ValueType_, Codec_>::get(Index n) const
 {
     if (this->isCompressed())           const_cast<TypedAttributeArray*>(this)->decompress();
     else if (this->isOutOfCore())       this->doLoad();
+    else if (n >= this->size())         OPENVDB_THROW(IndexError, "Out-of-range access.");
 
     return this->getUnsafe(n);
 }
@@ -932,6 +934,7 @@ TypedAttributeArray<ValueType_, Codec_>::getUnsafe(Index n, T& val) const
 {
     assert(!this->isCompressed());
     assert(!this->isOutOfCore());
+    assert(n < this->size());
 
     ValueType tmp;
     Codec::decode(/*in=*/mData[mIsUniform ? 0 : n], /*out=*/tmp);
@@ -946,6 +949,7 @@ TypedAttributeArray<ValueType_, Codec_>::get(Index n, T& val) const
 {
     if (this->isCompressed())           const_cast<TypedAttributeArray*>(this)->decompress();
     else if (this->isOutOfCore())       this->doLoad();
+    else if (n >= this->size())         OPENVDB_THROW(IndexError, "Out-of-range access.");
 
     this->getUnsafe(n, val);
 }
@@ -965,6 +969,7 @@ TypedAttributeArray<ValueType_, Codec_>::setUnsafe(Index n, const ValueType& val
 {
     assert(!this->isCompressed());
     assert(!this->isOutOfCore());
+    assert(n < this->size());
 
     if (mIsUniform)     this->expand();
 
@@ -978,6 +983,7 @@ TypedAttributeArray<ValueType_, Codec_>::set(Index n, const ValueType& val)
 {
     if (this->isCompressed())           this->decompress();
     else if (this->isOutOfCore())       this->doLoad();
+    else if (n >= this->size())         OPENVDB_THROW(IndexError, "Out-of-range access.");
 
     this->setUnsafe(n, val);
 }
@@ -990,6 +996,7 @@ TypedAttributeArray<ValueType_, Codec_>::setUnsafe(Index n, const T& val)
 {
     assert(!this->isCompressed());
     assert(!this->isOutOfCore());
+    assert(n < this->size());
 
     if (mIsUniform)     this->expand();
 
@@ -1005,6 +1012,7 @@ TypedAttributeArray<ValueType_, Codec_>::set(Index n, const T& val)
 {
     if (this->isCompressed())           this->decompress();
     else if (this->isOutOfCore())       this->doLoad();
+    else if (n >= this->size())         OPENVDB_THROW(IndexError, "Out-of-range access.");
 
     this->setUnsafe(n, val);
 }

--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -900,7 +900,7 @@ const Name
 AttributeSet::Descriptor::uniqueName(const Name& name) const
 {
     std::ostringstream ss;
-    for (size_t i = 0; i < this->size(); i++) {
+    for (size_t i = 0; i < this->size() + 1; i++) {
         ss.str("");
         ss << name << i;
         if (this->find(ss.str()) == INVALID_POS)    break;

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -525,6 +525,10 @@ template<typename T, Index Log2Dim>
 inline void
 PointDataLeafNode<T, Log2Dim>::initializeAttributes(const Descriptor::Ptr& descriptor, const size_t arrayLength)
 {
+    if (descriptor->size() == 0) {
+        OPENVDB_THROW(IndexError, "Cannot initialize attributes with an empty Descriptor");
+    }
+
     mAttributeSet.reset(new AttributeSet(descriptor, arrayLength));
 }
 

--- a/openvdb_points/unittest/TestAttributeArray.cc
+++ b/openvdb_points/unittest/TestAttributeArray.cc
@@ -346,6 +346,12 @@ TestAttributeArray::testAttributeArray()
         typedAttr.getUnsafe(0, value);
 
         CPPUNIT_ASSERT_DOUBLES_EQUAL(double(1.5), value, /*tolerance=*/double(0.0));
+
+        // out-of-range get() and set()
+        CPPUNIT_ASSERT_THROW(typedAttr.set(100, 0.5), openvdb::IndexError);
+        CPPUNIT_ASSERT_THROW(typedAttr.set(100, 1), openvdb::IndexError);
+        CPPUNIT_ASSERT_THROW(typedAttr.get(100, value), openvdb::IndexError);
+        CPPUNIT_ASSERT_THROW(typedAttr.get(100), openvdb::IndexError);
     }
 
     typedef openvdb::tools::FixedPointAttributeCodec<uint16_t> FixedPointCodec;

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -244,6 +244,10 @@ TestAttributeSet::testAttributeSetDescriptor()
 
     { // Test uniqueName
         Descriptor::Inserter names;
+        Descriptor::Ptr emptyDescr = Descriptor::create(names.vec);
+        const openvdb::Name uniqueNameEmpty = emptyDescr->uniqueName("test");
+        CPPUNIT_ASSERT_EQUAL(uniqueNameEmpty, openvdb::Name("test0"));
+
         names.add("test", AttributeS::attributeType());
         names.add("test1", AttributeI::attributeType());
 

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -321,6 +321,13 @@ TestPointDataLeaf::testOffsets()
         typedef openvdb::tools::AttributeSet::Descriptor      Descriptor;
 
         Descriptor::Inserter names;
+
+        // empty Descriptor should throw on leaf node initialize
+        Descriptor::Ptr emptyDescriptor = Descriptor::create(names.vec);
+        LeafType* emptyLeafNode = new LeafType();
+        CPPUNIT_ASSERT_THROW(emptyLeafNode->initializeAttributes(emptyDescriptor, 5), openvdb::IndexError);
+
+        // create a non-empty Descriptor
         names.add("density", AttributeS::attributeType());
         names.add("id", AttributeI::attributeType());
         Descriptor::Ptr descriptor = Descriptor::create(names.vec);


### PR DESCRIPTION
* Add some out-of-range checks to the safe versions of attribute setters and getters (unsafe versions still have no out-of-range checks for performance).
* Can no longer initialize attributes on a PointDataLeaf with a Descriptor with no attributes.
* Fix bug in uniqueName method when no attributes are present.