### PR TITLE
Introduce beginIndex() as well as beginIndexAll()

### DIFF
--- a/openvdb_points/tools/IndexIterator.h
+++ b/openvdb_points/tools/IndexIterator.h
@@ -203,7 +203,7 @@ template<typename TreeT, typename ValueT> struct IndexIterTraits;
 
 template<typename TreeT>
 struct IndexIterTraits<TreeT, typename TreeT::LeafNodeType::ValueAllCIter> {
-    typedef IndexIter Iterator;
+    typedef typename TreeT::LeafNodeType::IndexAllIter Iterator;
     static Iterator begin(const typename TreeT::LeafNodeType& leaf) {
         return Iterator(leaf.beginIndexAll());
     }

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -477,11 +477,13 @@ public:
         const PointDataLeafNode, const ValueType, ChildAll> ChildAllCIter;
 
     typedef openvdb::tools::IndexIter IndexIter;
+    typedef ValueIndexIter<ValueAllCIter> IndexAllIter;
     typedef ValueIndexIter<ValueOnCIter> IndexOnIter;
     typedef ValueIndexIter<ValueOffCIter> IndexOffIter;
 
     /// @brief Leaf index iterator
-    IndexIter beginIndexAll() const;
+    IndexIter beginIndex() const;
+    IndexAllIter beginIndexAll() const;
     IndexOnIter beginIndexOn() const;
     IndexOffIter beginIndexOff() const;
     /// @brief Leaf index iterator from voxel
@@ -769,11 +771,19 @@ PointDataLeafNode<T, Log2Dim>::groupWriteHandle(const Name& name)
 
 template<typename T, Index Log2Dim>
 inline IndexIter
-PointDataLeafNode<T, Log2Dim>::beginIndexAll() const
+PointDataLeafNode<T, Log2Dim>::beginIndex() const
 {
     const ValueType start = 0;
     const ValueType end = this->getValue(NUM_VOXELS - 1);
     return IndexIter(start, end);
+}
+
+template<typename T, Index Log2Dim>
+inline typename PointDataLeafNode<T, Log2Dim>::IndexAllIter
+PointDataLeafNode<T, Log2Dim>::beginIndexAll() const
+{
+    ValueAllCIter iter = this->cbeginValueAll();
+    return IndexAllIter(iter);
 }
 
 template<typename T, Index Log2Dim>
@@ -813,7 +823,7 @@ template<typename T, Index Log2Dim>
 inline Index64
 PointDataLeafNode<T, Log2Dim>::pointCount() const
 {
-    return iterCount(this->beginIndexAll());
+    return iterCount(this->beginIndex());
 }
 
 template<typename T, Index Log2Dim>
@@ -838,7 +848,7 @@ template<typename T, Index Log2Dim>
 inline Index64
 PointDataLeafNode<T, Log2Dim>::groupPointCount(const Name& groupName) const
 {
-    IndexIter indexIter = this->beginIndexAll();
+    IndexIter indexIter = this->beginIndex();
     GroupFilter filter(GroupFilter::create(*this, GroupFilter::Data(groupName)));
     FilterIndexIter<IndexIter, GroupFilter> filterIndexIter(indexIter, filter);
     return iterCount(filterIndexIter);

--- a/openvdb_points/tools/PointGroup.h
+++ b/openvdb_points/tools/PointGroup.h
@@ -143,7 +143,7 @@ struct CopyGroupOp {
             GroupHandle sourceGroup = leaf->groupHandle(mSourceIndex);
             GroupWriteHandle targetGroup = leaf->groupWriteHandle(mTargetIndex);
 
-            for (IndexIter iter = leaf->beginIndexAll(); iter; ++iter) {
+            for (IndexIter iter = leaf->beginIndex(); iter; ++iter) {
                 const bool groupOn = sourceGroup.get(*iter);
                 targetGroup.set(*iter, groupOn);
             }


### PR DESCRIPTION
To provide the option to iterate over all points for all voxels or just all points