### PR TITLE
Descriptor Name Masks

### DIFF
--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -360,15 +360,13 @@ public:
     /// Return a unique name for an attribute array based on given name
     const Name uniqueName(const Name& name) const;
 
-    /// Return true if the group name is valid
-    static bool validGroupName(const Name& name)
-    {
-        struct Internal {
-            static bool isNotAlnumUnderscore(int c) { return !(isalnum(c) || (c == '_')); }
-        };
-        if (name.empty())   return false;
-        return find_if(name.begin(), name.end(), Internal::isNotAlnumUnderscore) == name.end();
-    }
+    /// Return true if the name is valid
+    static bool validName(const Name& name);
+
+    /// Extract each name from nameStr into includeNames, or into excludeNames if name prefixed with caret
+    static void parseNames( std::vector<std::string>& includeNames,
+                            std::vector<std::string>& excludeNames,
+                            const std::string& nameStr);
 
     /// Serialize this descriptor to the given stream.
     void write(std::ostream&) const;

--- a/openvdb_points/tools/PointGroup.h
+++ b/openvdb_points/tools/PointGroup.h
@@ -53,15 +53,6 @@ OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
 namespace tools {
 
-/// @brief Parse and extract groups to include and exclude from the input string.
-///
-/// @param includeGroups the vector of group names to include.
-/// @param excludeGroups the vector of group names to exclude.
-/// @param groupStr      the input string from which to extract the group names.
-inline void parsePointGroups(   std::vector<std::string>& includeGroups,
-                                std::vector<std::string>& excludeGroups,
-                                const std::string& groupStr);
-
 /// @brief Delete any group that is not present in the Descriptor.
 ///
 /// @param groups        the vector of group names.
@@ -462,41 +453,6 @@ private:
 
 
 } // namespace point_group_internal
-
-
-////////////////////////////////////////
-
-
-inline void parsePointGroups(   std::vector<std::string>& includeGroups,
-                                std::vector<std::string>& excludeGroups,
-                                const std::string& groupStr)
-{
-    std::stringstream pointGroupsStream(groupStr);
-
-    std::istream_iterator<std::string> it(pointGroupsStream);
-    std::istream_iterator<std::string> end;
-    std::vector<std::string> groups(it, end);
-
-    for (std::vector<std::string>::const_iterator   it = groups.begin(),
-                                                    itEnd = groups.end(); it != itEnd; ++it)
-    {
-        std::string group = *it;
-
-        if (group == "^") {
-            throw RuntimeError("Negate character (^) has no VDB Points group name");
-        }
-
-        const bool negate = group.length() > 0 && group[0] == '^';
-        if (negate) group = group.substr(1, group.length()-1);
-
-        if (!AttributeSet::Descriptor::validGroupName(group)) {
-            throw RuntimeError(std::string("VDB Points group name contains invalid characters - ") + group);
-        }
-
-        if (negate)     excludeGroups.push_back(group);
-        else            includeGroups.push_back(group);
-    }
-}
 
 
 ////////////////////////////////////////

--- a/openvdb_points/unittest/TestPointGroup.cc
+++ b/openvdb_points/unittest/TestPointGroup.cc
@@ -48,7 +48,7 @@ public:
     virtual void tearDown() { openvdb::uninitialize(); openvdb::points::uninitialize(); }
 
     CPPUNIT_TEST_SUITE(TestPointGroup);
-    CPPUNIT_TEST(testParse);
+    CPPUNIT_TEST(testDescriptor);
     CPPUNIT_TEST(testAppendDrop);
     CPPUNIT_TEST(testCompact);
     CPPUNIT_TEST(testSet);
@@ -56,7 +56,7 @@ public:
 
     CPPUNIT_TEST_SUITE_END();
 
-    void testParse();
+    void testDescriptor();
     void testAppendDrop();
     void testCompact();
     void testSet();
@@ -116,75 +116,9 @@ namespace {
 
 
 void
-TestPointGroup::testParse()
+TestPointGroup::testDescriptor()
 {
-    { // empty string (by convention interpreted as all)
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        parsePointGroups(includeGroups, excludeGroups, "");
-        CPPUNIT_ASSERT(testStringVector(includeGroups));
-        CPPUNIT_ASSERT(testStringVector(excludeGroups));
-    }
-
-    { // one include group
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        parsePointGroups(includeGroups, excludeGroups, "group1");
-        CPPUNIT_ASSERT(testStringVector(includeGroups, "group1"));
-        CPPUNIT_ASSERT(testStringVector(excludeGroups));
-    }
-
-    { // two include groups
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        parsePointGroups(includeGroups, excludeGroups, "group1 group2");
-        CPPUNIT_ASSERT(testStringVector(includeGroups, "group1", "group2"));
-        CPPUNIT_ASSERT(testStringVector(excludeGroups));
-    }
-
-    { // one include, one exclude group
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        parsePointGroups(includeGroups, excludeGroups, "group1 ^group2");
-        CPPUNIT_ASSERT(testStringVector(includeGroups, "group1"));
-        CPPUNIT_ASSERT(testStringVector(excludeGroups, "group2"));
-    }
-
-    { // one include, one exclude group
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        parsePointGroups(includeGroups, excludeGroups, "^group1 group2");
-        CPPUNIT_ASSERT(testStringVector(includeGroups, "group2"));
-        CPPUNIT_ASSERT(testStringVector(excludeGroups, "group1"));
-    }
-
-    { // two exclude groups
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        parsePointGroups(includeGroups, excludeGroups, "^group1 ^group2");
-        CPPUNIT_ASSERT(testStringVector(includeGroups));
-        CPPUNIT_ASSERT(testStringVector(excludeGroups, "group1", "group2"));
-    }
-
-    { // two include groups, two exclude groups
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        parsePointGroups(includeGroups, excludeGroups, "group1 ^group2 ^group3 group4");
-        CPPUNIT_ASSERT(testStringVector(includeGroups, "group1", "group4"));
-        CPPUNIT_ASSERT(testStringVector(excludeGroups, "group2", "group3"));
-    }
-
-    { // two include groups, one isolated negate character
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        CPPUNIT_ASSERT_THROW(parsePointGroups(includeGroups, excludeGroups, "group1 ^ group2"), RuntimeError);
-    }
-
-    { // invalid character in group name
-        std::vector<std::string> includeGroups;
-        std::vector<std::string> excludeGroups;
-        CPPUNIT_ASSERT_THROW(parsePointGroups(includeGroups, excludeGroups, "group$1"), RuntimeError);
-    }
+    // test missing groups deletion
 
     { // no groups, empty Descriptor
         std::vector<std::string> groups;

--- a/openvdb_points_houdini/houdini/SHOP_OpenVDB_Points.cc
+++ b/openvdb_points_houdini/houdini/SHOP_OpenVDB_Points.cc
@@ -92,10 +92,14 @@ SHOP_OpenVDB_Points::buildShaderString(UT_String &result, fpreal now,
     UT_String groupMaskStr = "";
     evalString(groupMaskStr, "groupmask", 0, now);
 
+    UT_String attrMaskStr = "";
+    evalString(attrMaskStr, "attrmask", 0, now);
+
     std::stringstream ss;
     ss << SHOP_OpenVDB_Points::nodeName();
     ss << " file \"" << fileStr.toStdString() << "\"";
     ss << " groupmask \"" << groupMaskStr.toStdString() << "\"";
+    ss << " attrmask \"" << attrMaskStr.toStdString() << "\"";
 
     result = ss.str();
     return true;
@@ -125,7 +129,11 @@ newShopOperator(OP_OperatorTable *table)
 
     parms.add(hutil::ParmFactory(PRM_STRING, "groupmask", "Group Mask")
         .setDefault("")
-        .setHelpText("Specify VDB Points Groups to use."));
+        .setHelpText("Specify VDB Points Groups to use. (Default is all groups)"));
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "attrmask", "Attribute Mask")
+        .setDefault("")
+        .setHelpText("Specify VDB Points Attributes to use. (Default is all attributes)"));
 
     //////////
     // Register this operator.

--- a/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
+++ b/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
@@ -829,7 +829,10 @@ SOP_OpenVDB_Points::cookMySop(OP_Context& context)
 
             std::vector<std::string> includeGroups;
             std::vector<std::string> excludeGroups;
-            openvdb::tools::parsePointGroups(includeGroups, excludeGroups, pointsGroup);
+            openvdb::tools::AttributeSet::Descriptor::parseNames(includeGroups, excludeGroups, pointsGroup);
+
+            // passing an empty vector of attribute names implies that all attributes should be converted
+            const std::vector<std::string> emptyNameVector;
 
             // Mesh each VDB primitive independently
             for (hvdb::VdbPrimCIterator vdbIt(ptGeo, group); vdbIt; ++vdbIt) {
@@ -841,7 +844,7 @@ SOP_OpenVDB_Points::cookMySop(OP_Context& context)
 
                 const PointDataGrid& grid = static_cast<const PointDataGrid&>(baseGrid);
 
-                hvdbp::convertPointDataGridToHoudini(geo, grid, includeGroups, excludeGroups);
+                hvdbp::convertPointDataGridToHoudini(geo, grid, emptyNameVector, includeGroups, excludeGroups);
 
                 gdp->merge(geo);
             }

--- a/openvdb_points_houdini/houdini/SOP_OpenVDB_Points_Group.cc
+++ b/openvdb_points_houdini/houdini/SOP_OpenVDB_Points_Group.cc
@@ -505,7 +505,7 @@ SOP_OpenVDB_Points_Group::evalGroupParms(OP_Context& context, GroupParms& parms)
     evalString(pointsGroupStr, "vdbpointsgroup", 0, time);
     const std::string pointsGroup = pointsGroupStr.toStdString();
 
-    openvdb::tools::parsePointGroups(parms.mIncludeGroups, parms.mExcludeGroups, pointsGroup);
+    openvdb::tools::AttributeSet::Descriptor::parseNames(parms.mIncludeGroups, parms.mExcludeGroups, pointsGroup);
 
     if (parms.mIncludeGroups.size() > 0 || parms.mExcludeGroups.size() > 0) {
         parms.mOpGroup = true;
@@ -527,7 +527,7 @@ SOP_OpenVDB_Points_Group::evalGroupParms(OP_Context& context, GroupParms& parms)
         addWarning(SOP_MESSAGE, "Cannot create a group with an empty name, changing to _");
         groupName = "_";
     }
-    else if (!AttributeSet::Descriptor::validGroupName(groupName)) {
+    else if (!AttributeSet::Descriptor::validName(groupName)) {
         addError(SOP_MESSAGE, ("Group name contains invalid characters - " + groupName).c_str());
         return error();
     }


### PR DESCRIPTION
Add enforced naming rules for groups and attributes to AttributeSet::Descriptor, and name mask parsing. Extend convertPointDataGridToHoudini to take an attribute mask.