### PR TITLE
AttributeSet Construction Improvements

### DIFF
--- a/openvdb_points/tools/AttributeArrayString.cc
+++ b/openvdb_points/tools/AttributeArrayString.cc
@@ -175,17 +175,17 @@ StringAttributeHandle::StringAttributeHandle(const AttributeArray& array,
 }
 
 
-Name StringAttributeHandle::get(Index n) const
+Name StringAttributeHandle::get(Index n, Index m) const
 {
     Name name;
-    this->get(name, n);
+    this->get(name, n, m);
     return name;
 }
 
 
-void StringAttributeHandle::get(Name& name, Index n) const
+void StringAttributeHandle::get(Name& name, Index n, Index m) const
 {
-    StringIndexType index = mHandle.get(n);
+    StringIndexType index = mHandle.get(n, m);
 
     // index zero is reserved for an empty string
 
@@ -267,6 +267,13 @@ void StringAttributeWriteHandle::set(Index n, const Name& name)
 {
     Index index = getIndex(name);
     mWriteHandle.set(n, /*stride*/0, index);
+}
+
+
+void StringAttributeWriteHandle::set(Index n, Index m, const Name& name)
+{
+    Index index = getIndex(name);
+    mWriteHandle.set(n, m, index);
 }
 
 

--- a/openvdb_points/tools/AttributeArrayString.h
+++ b/openvdb_points/tools/AttributeArrayString.h
@@ -146,8 +146,8 @@ public:
     size_t size() const { return mHandle.size(); }
     bool isUniform() const { return mHandle.isUniform(); }
 
-    Name get(Index n) const;
-    void get(Name& name, Index n) const;
+    Name get(Index n, Index m = 0) const;
+    void get(Name& name, Index n, Index m = 0) const;
 
 protected:
     AttributeHandle<StringIndexType, StringCodec<false> >   mHandle;
@@ -188,6 +188,7 @@ public:
 
     /// Set the value of the index to @param name
     void set(Index n, const Name& name);
+    void set(Index n, Index m, const Name& name);
 
     /// Reset the value cache from the metadata
     void resetCache();

--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -327,6 +327,10 @@ AttributeSet::appendAttribute(  const Name& name,
                                 const Index stride,
                                 Metadata::Ptr defaultValue)
 {
+    if (stride < 1) {
+        OPENVDB_THROW(ValueError, "Cannot append attributes with a stride of less than one.")
+    }
+
     Descriptor::Ptr descriptor = mDescr->duplicateAppend(name, type);
 
     // store the attribute default value in the descriptor metadata

--- a/openvdb_points/tools/AttributeSet.cc
+++ b/openvdb_points/tools/AttributeSet.cc
@@ -114,7 +114,13 @@ AttributeSet::AttributeSet(const AttributeSet& attrSet, size_t arrayLength)
     for (Descriptor::ConstIterator it = mDescr->map().begin(),
         end = mDescr->map().end(); it != end; ++it) {
         const size_t pos = it->second;
-        mAttrs[pos] = AttributeArray::create(mDescr->type(pos), arrayLength, 1);
+        AttributeArray::Ptr array = AttributeArray::create(mDescr->type(pos), arrayLength, 1);
+
+        // transfer hidden and transient flags
+        if (attrSet.getConst(pos)->isHidden())      array->setHidden(true);
+        if (attrSet.getConst(pos)->isTransient())   array->setTransient(true);
+
+        mAttrs[pos] = array;
     }
 }
 

--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -51,6 +51,9 @@
 #include <openvdb_points/tools/AttributeArray.h>
 
 
+class TestAttributeSet;
+
+
 namespace openvdb {
 OPENVDB_USE_VERSION_NAMESPACE
 namespace OPENVDB_VERSION_NAME {
@@ -98,6 +101,9 @@ public:
 
     /// Construct from the given descriptor
     explicit AttributeSet(const DescriptorPtr&, size_t arrayLength = 1);
+
+    /// Construct from the given AttributeSet
+    AttributeSet(const AttributeSet&, size_t arrayLength);
 
     /// Shallow copy constructor, the descriptor and attribute arrays will be shared.
     AttributeSet(const AttributeSet&);
@@ -287,18 +293,11 @@ public:
     /// Copy constructor
     Descriptor(const Descriptor&);
 
-    /// Create a new descriptor from the given attribute and type name pairs.
-    static Ptr create(const NameAndTypeVec&);
-
-    /// Create a new descriptor from the given attribute and type name pairs
-    /// and copy the group maps and metamap.
-    static Ptr create(const NameAndTypeVec&, const NameToPosMap&, const MetaMap&);
-
     /// Create a new descriptor from a position attribute type and assumes "P" (for convenience).
     static Ptr create(const NamePair&);
 
     /// Create a new descriptor as a duplicate with a new attribute appended
-    Ptr duplicateAppend(const NameAndType& attribute) const;
+    Ptr duplicateAppend(const Name& name, const NamePair& type) const;
 
     /// Create a new descriptor as a duplicate with existing attributes dropped
     Ptr duplicateDrop(const std::vector<size_t>& pos) const;
@@ -353,9 +352,6 @@ public:
     /// Return a reference to the name-to-position group map.
     const NameToPosMap& groupMap() const { return mGroupMap; }
 
-    /// Append to a vector of names and types from this Descriptor in position order
-    void appendTo(NameAndTypeVec& attrs) const;
-
     /// Return @c true if group exists
     bool hasGroup(const Name& group) const;
     /// Define a group name to offset mapping
@@ -381,8 +377,18 @@ public:
     /// Unserialize this transform from the given stream.
     void read(std::istream&);
 
-private:
+protected:
+    /// Append to a vector of names and types from this Descriptor in position order
+    void appendTo(NameAndTypeVec& attrs) const;
+
+    /// Create a new descriptor from the given attribute and type name pairs
+    /// and copy the group maps and metamap.
+    static Ptr create(const NameAndTypeVec&, const NameToPosMap&, const MetaMap&);
+
     size_t insert(const std::string& name, const NamePair& typeName);
+
+private:
+    friend class ::TestAttributeSet;
 
     NameToPosMap                mNameMap;
     std::vector<NamePair>       mTypes;

--- a/openvdb_points/tools/PointAttribute.h
+++ b/openvdb_points/tools/PointAttribute.h
@@ -152,10 +152,12 @@ struct AppendAttributeOp {
 
     AppendAttributeOp(  PointDataTreeType& tree,
                         AttributeSet::DescriptorPtr& descriptor,
+                        const size_t pos,
                         const bool hidden = false,
                         const bool transient = false)
         : mTree(tree)
         , mDescriptor(descriptor)
+        , mPos(pos)
         , mHidden(hidden)
         , mTransient(transient) { }
 
@@ -165,7 +167,7 @@ struct AppendAttributeOp {
 
             const AttributeSet::Descriptor& expected = leaf->attributeSet().descriptor();
 
-            AttributeArray::Ptr attribute = leaf->template appendAttribute<AttributeType>(expected, mDescriptor);
+            AttributeArray::Ptr attribute = leaf->appendAttribute(expected, mDescriptor, mPos);
 
             if (mHidden)      attribute->setHidden(true);
             if (mTransient)   attribute->setTransient(true);
@@ -176,6 +178,7 @@ struct AppendAttributeOp {
 
     PointDataTreeType&              mTree;
     AttributeSet::DescriptorPtr&    mDescriptor;
+    const size_t                    mPos;
     const bool                      mHidden;
     const bool                      mTransient;
 }; // class AppendAttributeOp
@@ -310,9 +313,13 @@ inline void appendAttribute(PointDataTree& tree,
         newDescriptor->setDefaultValue(name, *defaultValue);
     }
 
+    // extract new pos
+
+    const size_t pos = newDescriptor->find(name);
+
     // insert attributes using the new descriptor
 
-    AppendAttributeOp<AttributeType, PointDataTree> append(tree, newDescriptor, hidden, transient);
+    AppendAttributeOp<AttributeType, PointDataTree> append(tree, newDescriptor, pos, hidden, transient);
     tbb::parallel_for(typename tree::template LeafManager<PointDataTree>(tree).leafRange(), append);
 }
 

--- a/openvdb_points/tools/PointAttribute.h
+++ b/openvdb_points/tools/PointAttribute.h
@@ -148,7 +148,6 @@ struct AppendAttributeOp {
 
     typedef typename tree::LeafManager<PointDataTreeType>       LeafManagerT;
     typedef typename LeafManagerT::LeafRange                    LeafRangeT;
-    typedef AttributeSet::Descriptor::NameAndType               NameAndType;
 
     AppendAttributeOp(  PointDataTreeType& tree,
                         AttributeSet::DescriptorPtr& descriptor,
@@ -304,8 +303,7 @@ inline void appendAttribute(PointDataTree& tree,
 
     // create a new attribute descriptor
 
-    AttributeSet::Util::NameAndType nameAndType(name, AttributeType::attributeType());
-    Descriptor::Ptr newDescriptor = descriptor.duplicateAppend(nameAndType);
+    Descriptor::Ptr newDescriptor = descriptor.duplicateAppend(name, AttributeType::attributeType());
 
     // store the attribute default value in the descriptor metadata
 

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -541,10 +541,6 @@ template<typename T, Index Log2Dim>
 inline void
 PointDataLeafNode<T, Log2Dim>::initializeAttributes(const Descriptor::Ptr& descriptor, const size_t arrayLength)
 {
-    if (descriptor->size() == 0) {
-        OPENVDB_THROW(IndexError, "Cannot initialize attributes with an empty Descriptor");
-    }
-
     mAttributeSet.reset(new AttributeSet(descriptor, arrayLength));
 }
 
@@ -552,7 +548,7 @@ template<typename T, Index Log2Dim>
 inline void
 PointDataLeafNode<T, Log2Dim>::clearAttributes(const bool updateValueMask)
 {
-    mAttributeSet.reset(new AttributeSet(mAttributeSet->descriptorPtr(), 0));
+    mAttributeSet.reset(new AttributeSet(*mAttributeSet, 0));
 
     // zero voxel values
 

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -211,8 +211,11 @@ public:
     /// @param attribute Name and type of the attribute to append.
     /// @param expected Existing descriptor is expected to match this parameter.
     /// @param replacement New descriptor to replace the existing one.
+    /// @param pos Index of the new attribute in the descriptor replacement.
+    /// @param stride Stride of the attribute array.
     AttributeArray::Ptr appendAttribute(const Descriptor& expected, Descriptor::Ptr& replacement,
-                                        const size_t pos);
+                                        const size_t pos, const Index stride = 1);
+
     /// @brief Drop list of attributes.
     /// @param pos vector of attribute indices to drop
     /// @param expected Existing descriptor is expected to match this parameter.
@@ -579,9 +582,9 @@ PointDataLeafNode<T, Log2Dim>::hasAttribute(const Name& attributeName) const
 template<typename T, Index Log2Dim>
 inline AttributeArray::Ptr
 PointDataLeafNode<T, Log2Dim>::appendAttribute( const Descriptor& expected, Descriptor::Ptr& replacement,
-                                                const size_t pos)
+                                                const size_t pos, const Index stride)
 {
-    return mAttributeSet->appendAttribute(expected, replacement, pos);
+    return mAttributeSet->appendAttribute(expected, replacement, pos, stride);
 }
 
 template<typename T, Index Log2Dim>

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -211,8 +211,8 @@ public:
     /// @param attribute Name and type of the attribute to append.
     /// @param expected Existing descriptor is expected to match this parameter.
     /// @param replacement New descriptor to replace the existing one.
-    template <typename AttributeType>
-    AttributeArray::Ptr appendAttribute(const Descriptor& expected, Descriptor::Ptr& replacement);
+    AttributeArray::Ptr appendAttribute(const Descriptor& expected, Descriptor::Ptr& replacement,
+                                        const size_t pos);
     /// @brief Drop list of attributes.
     /// @param pos vector of attribute indices to drop
     /// @param expected Existing descriptor is expected to match this parameter.
@@ -581,11 +581,11 @@ PointDataLeafNode<T, Log2Dim>::hasAttribute(const Name& attributeName) const
 }
 
 template<typename T, Index Log2Dim>
-template <typename AttributeType>
 inline AttributeArray::Ptr
-PointDataLeafNode<T, Log2Dim>::appendAttribute(const Descriptor& expected, Descriptor::Ptr& replacement)
+PointDataLeafNode<T, Log2Dim>::appendAttribute( const Descriptor& expected, Descriptor::Ptr& replacement,
+                                                const size_t pos)
 {
-    return mAttributeSet->appendAttribute<AttributeType>(expected, replacement);
+    return mAttributeSet->appendAttribute(expected, replacement, pos);
 }
 
 template<typename T, Index Log2Dim>

--- a/openvdb_points/tools/PointGroup.h
+++ b/openvdb_points/tools/PointGroup.h
@@ -360,7 +360,7 @@ public:
 
         // compute total slots (one slot per bit of the group attributes)
 
-        const size_t groupAttributes = descriptor.count<GroupAttributeArray>();
+        const size_t groupAttributes = descriptor.count(GroupAttributeArray::attributeType());
 
         if (groupAttributes == 0)   return 0;
 
@@ -510,9 +510,11 @@ inline void appendGroup(PointDataTree& tree, const Name& group)
 
         descriptor = descriptor->duplicateAppend(groupAttribute);
 
+        const size_t pos = descriptor->find(groupName);
+
         // insert new group attribute
 
-        AppendAttributeOp<GroupAttributeArray, PointDataTree> append(tree, descriptor);
+        AppendAttributeOp<GroupAttributeArray, PointDataTree> append(tree, descriptor, pos);
         tbb::parallel_for(typename tree::template LeafManager<PointDataTree>(tree).leafRange(), append);
     }
     else {

--- a/openvdb_points/tools/PointGroup.h
+++ b/openvdb_points/tools/PointGroup.h
@@ -156,7 +156,6 @@ struct CopyGroupOp {
 
     typedef typename tree::LeafManager<PointDataTreeType>       LeafManagerT;
     typedef typename LeafManagerT::LeafRange                    LeafRangeT;
-    typedef AttributeSet::Descriptor::NameAndType               NameAndType;
     typedef AttributeSet::Descriptor::GroupIndex                GroupIndex;
 
     CopyGroupOp(PointDataTreeType& tree,
@@ -478,7 +477,6 @@ template <typename PointDataTree>
 inline void appendGroup(PointDataTree& tree, const Name& group)
 {
     typedef AttributeSet::Descriptor                              Descriptor;
-    typedef AttributeSet::Util::NameAndType                       NameAndType;
 
     using point_attribute_internal::AppendAttributeOp;
     using point_group_internal::GroupInfo;
@@ -506,9 +504,8 @@ inline void appendGroup(PointDataTree& tree, const Name& group)
         // find a new internal group name
 
         const Name groupName = descriptor->uniqueName("__group");
-        const NameAndType groupAttribute(groupName, GroupAttributeArray::attributeType());
 
-        descriptor = descriptor->duplicateAppend(groupAttribute);
+        descriptor = descriptor->duplicateAppend(groupName, GroupAttributeArray::attributeType());
 
         const size_t pos = descriptor->find(groupName);
 

--- a/openvdb_points/tools/PointGroup.h
+++ b/openvdb_points/tools/PointGroup.h
@@ -511,7 +511,7 @@ inline void appendGroup(PointDataTree& tree, const Name& group)
 
         // insert new group attribute
 
-        AppendAttributeOp<GroupAttributeArray, PointDataTree> append(tree, descriptor, pos);
+        AppendAttributeOp<PointDataTree> append(tree, descriptor, pos);
         tbb::parallel_for(typename tree::template LeafManager<PointDataTree>(tree).leafRange(), append);
     }
     else {

--- a/openvdb_points/unittest/TestAttributeArray.cc
+++ b/openvdb_points/unittest/TestAttributeArray.cc
@@ -918,15 +918,13 @@ TestAttributeArray::testAttributeHandle()
     // create a Descriptor and AttributeSet
 
     typedef AttributeSet::Descriptor Descriptor;
-
-    Descriptor::Ptr descr = Descriptor::create(Descriptor::Inserter()
-        .add("pos", AttributeVec3f::attributeType())
-        .add("truncate", AttributeFH::attributeType())
-        .add("int", AttributeI::attributeType())
-        .vec);
+    Descriptor::Ptr descr = Descriptor::create(AttributeVec3f::attributeType());
 
     unsigned count = 50;
     AttributeSet attrSet(descr, /*arrayLength=*/count);
+
+    attrSet.appendAttribute("truncate", AttributeFH::attributeType());
+    attrSet.appendAttribute("int", AttributeI::attributeType());
 
     // check uniform value implementation
 

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -624,7 +624,7 @@ TestAttributeSet::testAttributeSet()
             attrSetC.makeUnique(0);
             attrSetC.makeUnique(1);
 
-            attrSetC.appendAttribute<AttributeS>("test", /*stride=*/1, defaultValueTest.copy());
+            attrSetC.appendAttribute("test", AttributeS::attributeType(), /*stride=*/1, defaultValueTest.copy());
 
             CPPUNIT_ASSERT(attributeSetMatchesDescriptor(attrSetC, *descrB));
         }
@@ -634,7 +634,7 @@ TestAttributeSet::testAttributeSet()
             attrSetC.makeUnique(0);
             attrSetC.makeUnique(1);
 
-            attrSetC.appendAttribute<AttributeS>(attrSetC.descriptor(), descrB);
+            attrSetC.appendAttribute(attrSetC.descriptor(), descrB, size_t(2));
 
             CPPUNIT_ASSERT(attributeSetMatchesDescriptor(attrSetC, *targetDescr));
         }

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -541,6 +541,17 @@ TestAttributeSet::testAttributeSet()
         CPPUNIT_ASSERT_THROW(AttributeSet attrSet(invalidDescr), openvdb::IndexError);
     }
 
+    { // transfer of flags on construction
+        AttributeSet attrSet(Descriptor::create(AttributeVec3s::attributeType()));
+        AttributeArray::Ptr array1 = attrSet.appendAttribute("hidden", AttributeS::attributeType());
+        array1->setHidden(true);
+        AttributeArray::Ptr array2 = attrSet.appendAttribute("transient", AttributeS::attributeType());
+        array2->setTransient(true);
+        AttributeSet attrSet2(attrSet, size_t(1));
+        CPPUNIT_ASSERT(attrSet2.getConst("hidden")->isHidden());
+        CPPUNIT_ASSERT(attrSet2.getConst("transient")->isTransient());
+    }
+
     // construct
 
     Descriptor::Ptr descr = Descriptor::create(AttributeVec3s::attributeType());

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -557,6 +557,8 @@ TestAttributeSet::testAttributeSet()
     Descriptor::Ptr descr = Descriptor::create(AttributeVec3s::attributeType());
     AttributeSet attrSetA(descr, /*arrayLength=*/50);
 
+    CPPUNIT_ASSERT_THROW(attrSetA.appendAttribute("id", AttributeI::attributeType(), /*stride=*/0), openvdb::ValueError);
+
     attrSetA.appendAttribute("id", AttributeI::attributeType());
 
     // check equality against duplicate array

--- a/openvdb_points/unittest/TestIndexFilter.cc
+++ b/openvdb_points/unittest/TestIndexFilter.cc
@@ -180,17 +180,18 @@ TestIndexFilter::testMultiGroupFilter()
     using namespace openvdb::tools;
 
     typedef PointDataTree::LeafNodeType LeafNode;
+    typedef openvdb::tools::TypedAttributeArray<Vec3f>    AttributeVec3f;
     typedef openvdb::tools::TypedAttributeArray<float>    AttributeS;
 
+    AttributeVec3f::registerType();
     AttributeS::registerType();
     GroupAttributeArray::registerType();
 
     PointDataTree tree;
     LeafNode* leaf = tree.touchLeaf(openvdb::Coord(0, 0, 0));
 
-    AttributeSet::Descriptor::Inserter names;
-    names.add("density", AttributeS::attributeType());
-    AttributeSet::Descriptor::Ptr descriptor = AttributeSet::Descriptor::create(names.vec);
+    typedef AttributeSet::Descriptor Descriptor;
+    Descriptor::Ptr descriptor = Descriptor::create(AttributeVec3f::attributeType());
 
     const size_t size = 5;
 

--- a/openvdb_points/unittest/TestPointAttribute.cc
+++ b/openvdb_points/unittest/TestPointAttribute.cc
@@ -100,8 +100,42 @@ TestPointAttribute::testAppendDrop()
     // check just one attribute exists (position)
     CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().size(), size_t(1));
 
+    { // append an attribute, different initial values and collapse
+        appendAttribute<AttributeI>(tree,  "id",
+                                    /*uniformValue*/zeroVal<AttributeI::ValueType>());
+
+        CPPUNIT_ASSERT(tree.beginLeaf()->hasAttribute("id"));
+
+        AttributeArray& array = tree.beginLeaf()->attributeArray("id");
+        CPPUNIT_ASSERT(array.isUniform());
+        CPPUNIT_ASSERT_EQUAL(AttributeI::cast(array).get(0), zeroVal<AttributeI::ValueType>());
+
+        dropAttribute(tree, "id");
+
+        appendAttribute<AttributeI>(tree,  "id",
+                                    AttributeI::ValueType(10));
+
+        CPPUNIT_ASSERT(tree.beginLeaf()->hasAttribute("id"));
+
+        array = tree.beginLeaf()->attributeArray("id");
+        CPPUNIT_ASSERT(array.isUniform());
+        CPPUNIT_ASSERT_EQUAL(AttributeI::cast(array).get(0), AttributeI::ValueType(10));
+
+        array.expand();
+        CPPUNIT_ASSERT(!array.isUniform());
+
+        collapseAttribute<AttributeI>(tree, "id", AttributeI::ValueType(50));
+
+        array = tree.beginLeaf()->attributeArray("id");
+        CPPUNIT_ASSERT(array.isUniform());
+        CPPUNIT_ASSERT_EQUAL(AttributeI::cast(array).get(0), AttributeI::ValueType(50));
+
+        dropAttribute(tree, "id");
+    }
+
     { // append an attribute, check descriptors are as expected, default value test
         appendAttribute<AttributeI>(tree,  "id",
+                                /*uniformValue*/zeroVal<AttributeI::ValueType>(),
                                 /*defaultValue*/TypedMetadata<AttributeI::ValueType>(AttributeI::ValueType(10)).copy(),
                                 /*hidden=*/false, /*transient=*/false);
 
@@ -239,10 +273,10 @@ TestPointAttribute::testAppendDrop()
     }
 
     { // append attributes marked as hidden, transient, group and string
-        appendAttribute<AttributeF>(tree, "testHidden", Metadata::Ptr(), true, false);
-        appendAttribute<AttributeF>(tree, "testTransient", Metadata::Ptr(), false, true);
-        appendAttribute<GroupAttributeArray>(tree, "testGroup", Metadata::Ptr(), false, false);
-        appendAttribute<StringAttributeArray>(tree, "testString", Metadata::Ptr(), false, false);
+        appendAttribute<AttributeF>(tree, "testHidden", zeroVal<AttributeF::ValueType>(), Metadata::Ptr(), true, false);
+        appendAttribute<AttributeF>(tree, "testTransient", zeroVal<AttributeF::ValueType>(), Metadata::Ptr(), false, true);
+        appendAttribute<GroupAttributeArray>(tree, "testGroup", zeroVal<GroupAttributeArray::ValueType>(), Metadata::Ptr(), false, false);
+        appendAttribute<StringAttributeArray>(tree, "testString", zeroVal<StringAttributeArray::ValueType>(), Metadata::Ptr(), false, false);
 
         const AttributeArray& arrayHidden = leafIter->attributeArray("testHidden");
         const AttributeArray& arrayTransient = leafIter->attributeArray("testTransient");
@@ -294,7 +328,7 @@ TestPointAttribute::testRename()
 
     const openvdb::TypedMetadata<float> defaultValue(5.0f);
 
-    appendAttribute<AttributeF>(tree, "test1", defaultValue.copy());
+    appendAttribute<AttributeF>(tree, "test1", zeroVal<AttributeF::ValueType>(), defaultValue.copy());
     appendAttribute<AttributeI>(tree, "id");
     appendAttribute<AttributeF>(tree, "test2");
 
@@ -342,7 +376,7 @@ TestPointAttribute::testRename()
     }
 
     { // don't rename group attributes
-        appendAttribute<GroupAttributeArray>(tree, "testGroup", Metadata::Ptr());
+        appendAttribute<GroupAttributeArray>(tree, "testGroup", zeroVal<GroupAttributeArray::ValueType>(), Metadata::Ptr());
         CPPUNIT_ASSERT_THROW(renameAttribute(tree, "testGroup", "testGroup2"), openvdb::KeyError);
     }
 

--- a/openvdb_points/unittest/TestPointConversion.cc
+++ b/openvdb_points/unittest/TestPointConversion.cc
@@ -49,10 +49,12 @@ public:
 
     CPPUNIT_TEST_SUITE(TestPointConversion);
     CPPUNIT_TEST(testPointConversion);
+    CPPUNIT_TEST(testStride);
 
     CPPUNIT_TEST_SUITE_END();
 
     void testPointConversion();
+    void testStride();
 
 }; // class TestPointConversion
 
@@ -70,23 +72,25 @@ struct AttributeWrapper
     struct Handle
     {
         Handle(AttributeWrapper<T>& attribute)
-            : mBuffer(attribute.mAttribute) { }
+            : mBuffer(attribute.mAttribute)
+            , mStride(attribute.mStride) { }
 
         template <typename ValueType>
-        void set(openvdb::Index offset, const ValueType& value) {
-            mBuffer[offset] = value;
+        void set(size_t n, openvdb::Index m, const ValueType& value) {
+            mBuffer[n * mStride + m] = value;
         }
 
         template <typename ValueType>
-        void set(openvdb::Index offset, const openvdb::math::Vec3<ValueType>& value) {
-            mBuffer[offset] = value;
+        void set(size_t n, openvdb::Index m, const openvdb::math::Vec3<ValueType>& value) {
+            mBuffer[n * mStride + m] = value;
         }
 
     private:
         std::vector<T>& mBuffer;
+        Index mStride;
     }; // struct Handle
 
-    AttributeWrapper() { }
+    explicit AttributeWrapper(const Index stride) : mStride(stride) { }
 
     void expand() { }
     void compact() { }
@@ -97,12 +101,13 @@ struct AttributeWrapper
     std::vector<T>& buffer() { return mAttribute; }
 
     template <typename ValueT>
-    void get(size_t n, ValueT& value) const { value = mAttribute[n]; }
+    void get(ValueT& value, size_t n, openvdb::Index m = 0) const { value = mAttribute[n * mStride + m]; }
     template <typename ValueT>
-    void getPos(size_t n, ValueT& value) const { this->get<ValueT>(n, value); }
+    void getPos(size_t n, ValueT& value) const { this->get<ValueT>(value, n); }
 
 private:
     std::vector<T> mAttribute;
+    Index mStride;
 }; // struct AttributeWrapper
 
 
@@ -130,6 +135,7 @@ struct PointData
 {
     int id;
     Vec3f position;
+    Vec3i xyz;
     float uniform;
     openvdb::Name string;
     short group;
@@ -140,8 +146,9 @@ struct PointData
 
 // Generate random points by uniformly distributing points
 // on a unit-sphere.
-void genPoints( const int numPoints, const double scale,
+void genPoints( const int numPoints, const double scale, const bool stride,
                 AttributeWrapper<Vec3f>& position,
+                AttributeWrapper<int>& xyz,
                 AttributeWrapper<int>& id,
                 AttributeWrapper<float>& uniform,
                 AttributeWrapper<openvdb::Name>& string,
@@ -157,12 +164,14 @@ void genPoints( const int numPoints, const double scale,
     openvdb::Vec3f pos;
 
     position.resize(n*n);
+    xyz.resize(stride ? n*n*3 : 1);
     id.resize(n*n);
     uniform.resize(n*n);
     string.resize(n*n);
     group.resize(n*n);
 
     AttributeWrapper<Vec3f>::Handle positionHandle(position);
+    AttributeWrapper<int>::Handle xyzHandle(xyz);
     AttributeWrapper<int>::Handle idHandle(id);
     AttributeWrapper<float>::Handle uniformHandle(uniform);
     AttributeWrapper<openvdb::Name>::Handle stringHandle(string);
@@ -187,17 +196,24 @@ void genPoints( const int numPoints, const double scale,
             pos[1] = std::sin(theta)*std::sin(phi)*scale;
             pos[2] = std::cos(theta)*scale;
 
-            positionHandle.set(i, pos);
-            idHandle.set(i, i);
-            uniformHandle.set(i, 100.0f);
+            positionHandle.set(i, /*stride*/0, pos);
+            idHandle.set(i, /*stride*/0, i);
+            uniformHandle.set(i, /*stride*/0, 100.0f);
+
+            if (stride)
+            {
+                xyzHandle.set(i, 0, i);
+                xyzHandle.set(i, 1, i*i);
+                xyzHandle.set(i, 2, i*i*i);
+            }
 
             // add points with even id to the group
             if ((i % 2) == 0) {
                 group.setOffsetOn(i);
-                stringHandle.set(i, "testA");
+                stringHandle.set(i, /*stride*/0, "testA");
             }
             else {
-                stringHandle.set(i, "testB");
+                stringHandle.set(i, /*stride*/0, "testB");
             }
 
             i++;
@@ -225,13 +241,15 @@ TestPointConversion::testPointConversion()
 
     const unsigned long count(40000);
 
-    AttributeWrapper<Vec3f> position;
-    AttributeWrapper<int> id;
-    AttributeWrapper<float> uniform;
-    AttributeWrapper<openvdb::Name> string;
+    AttributeWrapper<Vec3f> position(1);
+    AttributeWrapper<int> xyz(1);
+    AttributeWrapper<int> id(1);
+    AttributeWrapper<float> uniform(1);
+    AttributeWrapper<openvdb::Name> string(1);
     GroupWrapper group;
 
-    genPoints(count, /*scale=*/ 100.0, position, id, uniform, string, group);
+    genPoints(count, /*scale=*/ 100.0, /*stride=*/false,
+                position, xyz, id, uniform, string, group);
 
     CPPUNIT_ASSERT_EQUAL(position.size(), count);
     CPPUNIT_ASSERT_EQUAL(id.size(), count);
@@ -254,12 +272,12 @@ TestPointConversion::testPointConversion()
     // add id and populate
 
     appendAttribute<AttributeI>(tree, "id");
-    populateAttribute(tree, pointIndexGrid->tree(), "id", id);
+    populateAttribute(tree, indexTree, "id", id);
 
     // add uniform and populate
 
     appendAttribute<AttributeF>(tree, "uniform");
-    populateAttribute(tree, pointIndexGrid->tree(), "uniform", uniform);
+    populateAttribute(tree, indexTree, "uniform", uniform);
 
     // add string and populate
 
@@ -279,7 +297,7 @@ TestPointConversion::testPointConversion()
     inserter.insert("testA");
     inserter.insert("testB");
 
-    populateAttribute(tree, pointIndexGrid->tree(), "string", string);
+    populateAttribute(tree, indexTree, "string", string);
 
     // add group and set membership
 
@@ -306,10 +324,10 @@ TestPointConversion::testPointConversion()
 
     // convert back into linear point attribute data
 
-    AttributeWrapper<Vec3f> outputPosition;
-    AttributeWrapper<int> outputId;
-    AttributeWrapper<float> outputUniform;
-    AttributeWrapper<openvdb::Name> outputString;
+    AttributeWrapper<Vec3f> outputPosition(1);
+    AttributeWrapper<int> outputId(1);
+    AttributeWrapper<float> outputUniform(1);
+    AttributeWrapper<openvdb::Name> outputString(1);
     GroupWrapper outputGroup;
 
     // test offset the whole point block by an arbitrary amount
@@ -377,9 +395,9 @@ TestPointConversion::testPointConversion()
     getPointOffsets(pointOffsets, tree, includeGroups);
 
     convertPointDataGridPosition(outputPosition, *pointDataGrid, pointOffsets, startOffset, includeGroups);
-    convertPointDataGridAttribute(outputId, tree, pointOffsets, startOffset, idIndex, includeGroups);
-    convertPointDataGridAttribute(outputUniform, tree, pointOffsets, startOffset, uniformIndex, includeGroups);
-    convertPointDataGridAttribute(outputString, tree, pointOffsets, startOffset, stringIndex, includeGroups);
+    convertPointDataGridAttribute(outputId, tree, pointOffsets, startOffset, idIndex, /*stride*/1, includeGroups);
+    convertPointDataGridAttribute(outputUniform, tree, pointOffsets, startOffset, uniformIndex, /*stride*/1, includeGroups);
+    convertPointDataGridAttribute(outputString, tree, pointOffsets, startOffset, stringIndex, /*stride*/1, includeGroups);
     convertPointDataGridGroup(outputGroup, tree, pointOffsets, startOffset, groupIndex, includeGroups);
 
     CPPUNIT_ASSERT_EQUAL(size_t(outputPosition.size() - startOffset), size_t(halfCount));
@@ -415,6 +433,125 @@ TestPointConversion::testPointConversion()
         CPPUNIT_ASSERT_DOUBLES_EQUAL(position.buffer()[i*2].z(), pointData[i].position.z(), /*tolerance=*/1e-6);
     }
 }
+
+
+////////////////////////////////////////
+
+
+void
+TestPointConversion::testStride()
+{
+    // Define and register some common attribute types
+    typedef TypedAttributeArray<int32_t>        AttributeI;
+    typedef TypedAttributeArray<float>          AttributeF;
+    typedef TypedAttributeArray<openvdb::Vec3s> AttributeVec3s;
+
+    AttributeI::registerType();
+    AttributeF::registerType();
+    AttributeVec3s::registerType();
+
+    // generate points
+
+    const unsigned long count(40000);
+
+    AttributeWrapper<Vec3f> position(1);
+    AttributeWrapper<int> xyz(3);
+    AttributeWrapper<int> id(1);
+    AttributeWrapper<float> uniform(1);
+    AttributeWrapper<openvdb::Name> string(1);
+    GroupWrapper group;
+
+    genPoints(count, /*scale=*/ 100.0, /*stride=*/true,
+                position, xyz, id, uniform, string, group);
+
+    CPPUNIT_ASSERT_EQUAL(position.size(), count);
+    CPPUNIT_ASSERT_EQUAL(xyz.size(), count*3);
+    CPPUNIT_ASSERT_EQUAL(id.size(), count);
+
+    // convert point positions into a Point Data Grid
+
+    const float voxelSize = 1.0f;
+    openvdb::math::Transform::Ptr transform(openvdb::math::Transform::createLinearTransform(voxelSize));
+
+    PointIndexGrid::Ptr pointIndexGrid = createPointIndexGrid<PointIndexGrid>(position, *transform);
+    PointDataGrid::Ptr pointDataGrid = createPointDataGrid<PointDataGrid>(*pointIndexGrid, position,
+                                            AttributeVec3s::attributeType(), *transform);
+
+    PointIndexTree& indexTree = pointIndexGrid->tree();
+    PointDataTree& tree = pointDataGrid->tree();
+
+    // add id and populate
+
+    appendAttribute<AttributeI>(tree, "id");
+    populateAttribute(tree, indexTree, "id", id);
+
+    // add xyz and populate
+
+    appendAttribute<AttributeI>(tree, "xyz", /*stride=*/3);
+    populateAttribute(tree, indexTree, "xyz", xyz, /*stride=*/3);
+
+    // create accessor and iterator for Point Data Tree
+
+    PointDataTree::LeafCIter leafCIter = tree.cbeginLeaf();
+
+    CPPUNIT_ASSERT_EQUAL((unsigned long) 3, leafCIter->attributeSet().size());
+
+    CPPUNIT_ASSERT(leafCIter->attributeSet().find("id") != AttributeSet::INVALID_POS);
+    CPPUNIT_ASSERT(leafCIter->attributeSet().find("P") != AttributeSet::INVALID_POS);
+    CPPUNIT_ASSERT(leafCIter->attributeSet().find("xyz") != AttributeSet::INVALID_POS);
+
+    const size_t idIndex = leafCIter->attributeSet().find("id");
+    const size_t xyzIndex = leafCIter->attributeSet().find("xyz");
+
+    // convert back into linear point attribute data
+
+    AttributeWrapper<Vec3f> outputPosition(1);
+    AttributeWrapper<int> outputXyz(3);
+    AttributeWrapper<int> outputId(1);
+
+    // test offset the whole point block by an arbitrary amount
+
+    Index64 startOffset = 10;
+
+    outputPosition.resize(startOffset + position.size());
+    outputXyz.resize((startOffset + id.size())*3);
+    outputId.resize(startOffset + id.size());
+
+    std::vector<Index64> pointOffsets;
+    getPointOffsets(pointOffsets, tree);
+
+    convertPointDataGridPosition(outputPosition, *pointDataGrid, pointOffsets, startOffset);
+    convertPointDataGridAttribute(outputId, tree, pointOffsets, startOffset, idIndex);
+    convertPointDataGridAttribute(outputXyz, tree, pointOffsets, startOffset, xyzIndex, /*stride=*/3);
+
+    // pack and sort the new buffers based on id
+
+    std::vector<PointData> pointData;
+
+    pointData.resize(count);
+
+    for (unsigned int i = 0; i < count; i++) {
+        pointData[i].id = outputId.buffer()[startOffset + i];
+        pointData[i].position = outputPosition.buffer()[startOffset + i];
+        for (unsigned int j = 0; j < 3; j++) {
+            pointData[i].xyz[j] = outputXyz.buffer()[startOffset * 3 + i * 3 + j];
+        }
+    }
+
+    std::sort(pointData.begin(), pointData.end());
+
+    // compare old and new buffers
+
+    for (unsigned int i = 0; i < count; i++)
+    {
+        CPPUNIT_ASSERT_EQUAL(id.buffer()[i], pointData[i].id);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(position.buffer()[i].x(), pointData[i].position.x(), /*tolerance=*/1e-6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(position.buffer()[i].y(), pointData[i].position.y(), /*tolerance=*/1e-6);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(position.buffer()[i].z(), pointData[i].position.z(), /*tolerance=*/1e-6);
+        CPPUNIT_ASSERT_EQUAL(Vec3i(xyz.buffer()[i*3], xyz.buffer()[i*3+1], xyz.buffer()[i*3+2]), pointData[i].xyz);
+    }
+}
+
 
 // Copyright (c) 2015-2016 Double Negative Visual Effects
 // All rights reserved. This software is distributed under the

--- a/openvdb_points/unittest/TestPointGroup.cc
+++ b/openvdb_points/unittest/TestPointGroup.cc
@@ -300,12 +300,12 @@ TestPointGroup::testAppendDrop()
         appendGroup(tree, "test2");
 
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(2));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(1));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(1));
 
         dropGroups(tree);
 
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(0));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(0));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(0));
     }
 }
 
@@ -342,7 +342,7 @@ TestPointGroup::testCompact()
         }
 
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(8));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(1));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(1));
 
         appendGroup(tree, "test8");
 
@@ -351,7 +351,7 @@ TestPointGroup::testCompact()
         CPPUNIT_ASSERT(attributeSet.descriptor().hasGroup("test8"));
 
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(9));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(2));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(2));
     }
 
     { // drop first attribute then compact
@@ -359,7 +359,7 @@ TestPointGroup::testCompact()
 
         CPPUNIT_ASSERT(!attributeSet.descriptor().hasGroup("test5"));
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(8));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(2));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(2));
 
         compactGroups(tree);
 
@@ -367,7 +367,7 @@ TestPointGroup::testCompact()
         CPPUNIT_ASSERT(attributeSet.descriptor().hasGroup("test7"));
         CPPUNIT_ASSERT(attributeSet.descriptor().hasGroup("test8"));
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(8));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(1));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(1));
     }
 
     { // append seventeen groups, drop most of them, then compact
@@ -378,7 +378,7 @@ TestPointGroup::testCompact()
         }
 
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(17));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(3));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(3));
 
         // delete all but 0, 5, 9, 15
 
@@ -390,7 +390,7 @@ TestPointGroup::testCompact()
         }
 
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(3));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(3));
 
         // make a copy
 
@@ -401,12 +401,12 @@ TestPointGroup::testCompact()
         compactGroups(tree);
 
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count<GroupAttributeArray>(), size_t(1));
+        CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().count(GroupAttributeArray::attributeType()), size_t(1));
 
         // check descriptor has been deep copied
 
         CPPUNIT_ASSERT_EQUAL(tree2.cbeginLeaf()->attributeSet().descriptor().groupMap().size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(tree2.cbeginLeaf()->attributeSet().descriptor().count<GroupAttributeArray>(), size_t(3));
+        CPPUNIT_ASSERT_EQUAL(tree2.cbeginLeaf()->attributeSet().descriptor().count(GroupAttributeArray::attributeType()), size_t(3));
     }
 }
 

--- a/openvdb_points_houdini/houdini/GR_PrimVDBPoints.cc
+++ b/openvdb_points_houdini/houdini/GR_PrimVDBPoints.cc
@@ -683,7 +683,7 @@ struct PositionAttribute
             : mBuffer(attribute.mBuffer)
             , mPositionOffset(attribute.mPositionOffset) { }
 
-        void set(openvdb::Index offset, const ValueType& value) {
+        void set(openvdb::Index offset, openvdb::Index /*stride*/, const ValueType& value) {
             const ValueType transformedValue = value - mPositionOffset;
             mBuffer[offset] = UT_Vector3H(transformedValue.x(), transformedValue.y(), transformedValue.z());
         }
@@ -716,7 +716,7 @@ struct VectorAttribute
             : mBuffer(attribute.mBuffer) { }
 
         template <typename ValueType>
-        void set(openvdb::Index offset, const openvdb::math::Vec3<ValueType>& value) {
+        void set(openvdb::Index offset, openvdb::Index /*stride*/, const openvdb::math::Vec3<ValueType>& value) {
             mBuffer[offset] = UT_Vector3H(float(value.x()), float(value.y()), float(value.z()));
         }
 
@@ -1027,7 +1027,7 @@ GR_PrimVDBPoints::updateVec3Buffer( RE_Render* r,
         if (type == "vec3s") {
             VectorAttribute<Vec3f> typedAttribute(data);
             convertPointDataGridAttribute(typedAttribute, grid.tree(), pointOffsets,
-                                         /*startOffset=*/ 0, index, includeGroups);
+                                         /*startOffset=*/ 0, index, /*stride=*/1, includeGroups);
         }
 
         // unmap the buffer so it can be used by GL and set the cache version

--- a/openvdb_points_houdini/houdini/SOP_NodeVDBPoints.h
+++ b/openvdb_points_houdini/houdini/SOP_NodeVDBPoints.h
@@ -283,17 +283,25 @@ public:
                 const openvdb::Name valueType = type.first;
                 const openvdb::Name codecType = type.second;
 
+                infoStr << it->first << "[";
+
                 // if no value compression, hide the codec from the middle-click output
 
                 if (codecType == "null") {
                     infoStr << it->first << "[" << valueType << "]";
                 }
                 else if (isString(array)) {
-                    infoStr << it->first << "[str]";
+                    infoStr << "str";
                 }
                 else {
-                    infoStr << it->first << "[" << valueType << "_" << codecType << "]";
+                    infoStr << valueType << "_" << codecType;
                 }
+
+                if (array.isStrided()) {
+                    infoStr << "[" << array.stride() << "]";
+                }
+
+                infoStr << "]";
             }
 
             if (first)  infoStr << "<none>";

--- a/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
+++ b/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
@@ -102,7 +102,6 @@ attrStringTypeFromGAAttribute(GA_Attribute const * attribute)
     }
 
     const GA_AIFTuple* tupleAIF = attribute->getAIFTuple();
-
     if (!tupleAIF) {
         std::stringstream ss; ss << "Invalid attribute type - " << attribute->getName();
         throw std::runtime_error(ss.str());
@@ -137,7 +136,7 @@ attrStringTypeFromGAAttribute(GA_Attribute const * attribute)
 template <typename AttributeType>
 void
 convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree, const openvdb::Name& name,
-                            const GA_Attribute* const attribute, const GA_Defaults& defaults, const int compression = 0)
+                            const GA_Attribute* const attribute, const GA_Defaults& defaults, const Index stride)
 {
     typedef typename AttributeType::ValueType ValueType;
 
@@ -149,10 +148,10 @@ convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree
         defaultValue = TypedMetadata<ValueType>(value).copy();
     }
 
-    appendAttribute<AttributeType, PointDataTree>(tree, name, zeroVal<typename AttributeType::ValueType>(), defaultValue);
+    appendAttribute<AttributeType, PointDataTree>(tree, name, stride, zeroVal<typename AttributeType::ValueType>(), defaultValue);
 
     hvdbp::HoudiniReadAttribute<ValueType> houdiniAttribute(*attribute);
-    populateAttribute(tree, indexTree, name, houdiniAttribute);
+    populateAttribute(tree, indexTree, name, houdiniAttribute, stride);
 }
 
 void
@@ -174,15 +173,13 @@ convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree
     }
 
     const GA_AIFTuple* tupleAIF = attribute->getAIFTuple();
-
     if (!tupleAIF) {
         std::stringstream ss; ss << "Invalid attribute type - " << attribute->getName();
         throw std::runtime_error(ss.str());
     }
 
-    const GA_Storage storage = tupleAIF->getStorage(attribute);
-    const GA_Defaults& defaults = tupleAIF->getDefaults(attribute);
-
+    GA_Defaults defaults = tupleAIF->getDefaults(attribute);
+    GA_Storage storage = tupleAIF->getStorage(attribute);
     const int16_t width = static_cast<int16_t>(tupleAIF->getTupleSize(attribute));
 
     if (width == 1)
@@ -252,8 +249,50 @@ convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree
             convertAttributeFromHoudini<TypedAttributeArray<Vec3<double> > >(tree, indexTree, name, attribute, defaults, compression);
         }
     }
-    else
-    {
+    else if (width == 3 && storage == GA_STORE_REAL16) {
+        convertAttributeFromHoudini<TypedAttributeArray<Vec3<half> > >(tree, indexTree, name, attribute, defaults, 1);
+    }
+    else if (width == 3 && storage == GA_STORE_REAL32 && compression == NONE) {
+        convertAttributeFromHoudini<TypedAttributeArray<Vec3<float> > >(tree, indexTree, name, attribute, defaults, 1);
+    }
+    else if (width == 3 && storage == GA_STORE_REAL32 && compression == TRUNCATE) {
+        convertAttributeFromHoudini<TypedAttributeArray<Vec3<float>,
+                                    TruncateCodec> >(tree, indexTree, name, attribute, defaults, 1);
+    }
+    else if (width == 3 && storage == GA_STORE_REAL32 && compression == UNIT_VECTOR) {
+        convertAttributeFromHoudini<TypedAttributeArray<Vec3<float>,
+                                    UnitVecCodec> >(tree, indexTree, name, attribute, defaults, 1);
+    }
+    else if (width == 3 && storage == GA_STORE_REAL64) {
+        convertAttributeFromHoudini<TypedAttributeArray<Vec3<double> > >(tree, indexTree, name, attribute, defaults, 1);
+    }
+    else if (storage == GA_STORE_BOOL) {
+        convertAttributeFromHoudini<TypedAttributeArray<bool> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else if (storage == GA_STORE_INT16) {
+        convertAttributeFromHoudini<TypedAttributeArray<int16_t> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else if (storage == GA_STORE_INT32) {
+        convertAttributeFromHoudini<TypedAttributeArray<int32_t> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else if (storage == GA_STORE_INT64) {
+        convertAttributeFromHoudini<TypedAttributeArray<int64_t> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else if (storage == GA_STORE_REAL16) {
+        convertAttributeFromHoudini<TypedAttributeArray<float,
+                                    TruncateCodec> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else if (storage == GA_STORE_REAL32 && compression == NONE) {
+        convertAttributeFromHoudini<TypedAttributeArray<float> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else if (storage == GA_STORE_REAL32 && compression == TRUNCATE) {
+        convertAttributeFromHoudini<TypedAttributeArray<float,
+                                    TruncateCodec> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else if (storage == GA_STORE_REAL64) {
+        convertAttributeFromHoudini<TypedAttributeArray<double> >(tree, indexTree, name, attribute, defaults, width);
+    }
+    else {
         std::stringstream ss; ss << "Unknown attribute type - " << name;
         throw std::runtime_error(ss.str());
     }
@@ -294,8 +333,10 @@ createPointDataGrid(const GU_Detail& ptGeo, const openvdb::NamePair& positionAtt
 
     // Create PointPartitioner compatible P attribute wrapper (for now no offset filtering)
 
+    const GA_Attribute& positionAttribute = *ptGeo.getP();
+
     hvdbp::OffsetListPtr offsets;
-    hvdbp::HoudiniReadAttribute<openvdb::Vec3d> points(*ptGeo.getP(), offsets);
+    hvdbp::HoudiniReadAttribute<openvdb::Vec3d> points(positionAttribute, offsets);
 
     // Create PointIndexGrid used for consistent index ordering in all attribute conversion
 

--- a/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
+++ b/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
@@ -149,7 +149,7 @@ convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree
         defaultValue = TypedMetadata<ValueType>(value).copy();
     }
 
-    appendAttribute<AttributeType, PointDataTree>(tree, name, defaultValue);
+    appendAttribute<AttributeType, PointDataTree>(tree, name, zeroVal<typename AttributeType::ValueType>(), defaultValue);
 
     hvdbp::HoudiniReadAttribute<ValueType> houdiniAttribute(*attribute);
     populateAttribute(tree, indexTree, name, houdiniAttribute);


### PR DESCRIPTION
AttributeSets can now only be constructed from a Descriptor with position. A new AttributeSet constructor uses another AttributeSet for construction in order to ensure flags such as hidden and transient are passed along in construction.

There is now a non-templated version of appendAttribute as well as in the Leaf and AttributeSet.