### PR TITLE
Fix bug in stride runtime parameterization 

### DIFF
--- a/openvdb_points/tools/PointConversion.h
+++ b/openvdb_points/tools/PointConversion.h
@@ -108,7 +108,7 @@ createPointDataGrid(const std::vector<ValueT>& positions,
 /// @note   A @c PointIndexGrid to the points must be supplied to perform this
 ///         operation. This is required to ensure the same point index ordering.
 
-template <typename PointDataTreeT, typename PointIndexTreeT, typename PointArrayT>
+template <typename PointDataTreeT, typename PointIndexTreeT, typename PointArrayT, bool Strided>
 inline void
 populateAttribute(  PointDataTreeT& tree, const PointIndexTreeT& pointIndexTree,
                     const openvdb::Name& attributeName, const PointArrayT& data,
@@ -803,7 +803,7 @@ createPointDataGrid(const std::vector<ValueT>& positions,
 ////////////////////////////////////////
 
 
-template <typename PointDataTreeT, typename PointIndexTreeT, typename PointArrayT>
+template <typename PointDataTreeT, typename PointIndexTreeT, typename PointArrayT, bool Strided>
 inline void
 populateAttribute(  PointDataTreeT& tree, const PointIndexTreeT& pointIndexTree,
                     const openvdb::Name& attributeName, const PointArrayT& data, const Index stride)
@@ -824,17 +824,18 @@ populateAttribute(  PointDataTreeT& tree, const PointIndexTreeT& pointIndexTree,
 
     typename tree::template LeafManager<PointDataTreeT> leafManager(tree);
 
-    if (stride == 1) {
+    if (Strided) {
         PopulateAttributeOp<PointDataTreeT,
                             PointIndexTreeT,
-                            PointArrayT> populate(pointIndexTree, data, index);
+                            PointArrayT,
+                            /*stride=*/true> populate(pointIndexTree, data, index, stride);
         tbb::parallel_for(leafManager.leafRange(), populate);
     }
     else {
         PopulateAttributeOp<PointDataTreeT,
                             PointIndexTreeT,
                             PointArrayT,
-                            /*stride=*/true> populate(pointIndexTree, data, index, stride);
+                            /*stride=*/false> populate(pointIndexTree, data, index, stride);
         tbb::parallel_for(leafManager.leafRange(), populate);
     }
 }

--- a/openvdb_points/unittest/TestPointConversion.cc
+++ b/openvdb_points/unittest/TestPointConversion.cc
@@ -272,12 +272,12 @@ TestPointConversion::testPointConversion()
     // add id and populate
 
     appendAttribute<AttributeI>(tree, "id");
-    populateAttribute(tree, indexTree, "id", id);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>, false>(tree, indexTree, "id", id);
 
     // add uniform and populate
 
     appendAttribute<AttributeF>(tree, "uniform");
-    populateAttribute(tree, indexTree, "uniform", uniform);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<float>, false>(tree, indexTree, "uniform", uniform);
 
     // add string and populate
 
@@ -297,7 +297,7 @@ TestPointConversion::testPointConversion()
     inserter.insert("testA");
     inserter.insert("testB");
 
-    populateAttribute(tree, indexTree, "string", string);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<openvdb::Name>, false>(tree, indexTree, "string", string);
 
     // add group and set membership
 
@@ -483,12 +483,12 @@ TestPointConversion::testStride()
     // add id and populate
 
     appendAttribute<AttributeI>(tree, "id");
-    populateAttribute(tree, indexTree, "id", id);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>, false>(tree, indexTree, "id", id);
 
     // add xyz and populate
 
     appendAttribute<AttributeI>(tree, "xyz", /*stride=*/3);
-    populateAttribute(tree, indexTree, "xyz", xyz, /*stride=*/3);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>, true>(tree, indexTree, "xyz", xyz, /*stride=*/3);
 
     // create accessor and iterator for Point Data Tree
 


### PR DESCRIPTION
Switch to using stride compile-time parameters in point conversion to resolve this. Also fix an issue with passing the compression type instead of the stride for the Points SOP in certain cases. 