### PR TITLE
Add support for points stored in packed primitives

### DIFF
--- a/openvdb_points/tools/PointConversion.h
+++ b/openvdb_points/tools/PointConversion.h
@@ -73,11 +73,10 @@ namespace tools {
 /// @note   A @c PointIndexGrid to the points must be supplied to perform this
 ///         operation. Typically this is built implicitly by the PointDataGrid constructor.
 
-template<typename PointDataGridT, typename PositionArrayT, typename PointIndexGridT>
+template <typename CompressionT, typename PointDataGridT, typename PositionArrayT, typename PointIndexGridT>
 inline typename PointDataGridT::Ptr
 createPointDataGrid(const PointIndexGridT& pointIndexGrid, const PositionArrayT& positions,
-                    const openvdb::NamePair& positionType, const math::Transform& xform,
-                    Metadata::Ptr positionDefaultValue = Metadata::Ptr());
+                    const math::Transform& xform, Metadata::Ptr positionDefaultValue = Metadata::Ptr());
 
 
 /// @brief  Convenience method to create a @c PointDataGrid from a std::vector of
@@ -91,10 +90,9 @@ createPointDataGrid(const PointIndexGridT& pointIndexGrid, const PositionArrayT&
 /// @note   This method implicitly wraps the std::vector for a Point-Partitioner compatible
 ///         data structure and creates the required @c PointIndexGrid to the points.
 
-template <typename PointDataGridT, typename ValueT>
+template <typename CompressionT, typename PointDataGridT, typename ValueT>
 inline typename PointDataGridT::Ptr
-createPointDataGrid(const std::vector<ValueT>& positions,
-                    const openvdb::NamePair& positionType, const math::Transform& xform,
+createPointDataGrid(const std::vector<ValueT>& positions, const math::Transform& xform,
                     Metadata::Ptr positionDefaultValue = Metadata::Ptr());
 
 
@@ -731,19 +729,21 @@ struct ConvertPointDataGridGroupOp {
 ////////////////////////////////////////
 
 
-template<typename PointDataGridT, typename PositionArrayT, typename PointIndexGridT>
+template<typename CompressionT, typename PointDataGridT, typename PositionArrayT, typename PointIndexGridT>
 inline typename PointDataGridT::Ptr
 createPointDataGrid(const PointIndexGridT& pointIndexGrid, const PositionArrayT& positions,
-                    const openvdb::NamePair& positionType, const math::Transform& xform,
-                    Metadata::Ptr positionDefaultValue)
+                    const math::Transform& xform, Metadata::Ptr positionDefaultValue)
 {
     typedef typename PointDataGridT::TreeType                       PointDataTreeT;
     typedef typename PointIndexGridT::TreeType                      PointIndexTreeT;
     typedef typename tree::template LeafManager<PointDataTreeT>     LeafManagerT;
     typedef typename LeafManagerT::LeafRange                        LeafRangeT;
+    typedef TypedAttributeArray<Vec3f, CompressionT>                PositionAttributeT;
 
     using point_conversion_internal::InitialiseAttributesOp;
     using point_conversion_internal::PopulatePositionAttributeOp;
+
+    const NamePair positionType = PositionAttributeT::attributeType();
 
     // construct the Tree using a topology copy of the PointIndexGrid
 
@@ -786,17 +786,16 @@ createPointDataGrid(const PointIndexGridT& pointIndexGrid, const PositionArrayT&
 ////////////////////////////////////////
 
 
-template <typename PointDataGridT, typename ValueT>
+template <typename CompressionT, typename PointDataGridT, typename ValueT>
 inline typename PointDataGridT::Ptr
 createPointDataGrid(const std::vector<ValueT>& positions,
-                    const openvdb::NamePair& positionType,
                     const math::Transform& xform,
                     Metadata::Ptr positionDefaultValue)
 {
     const PointAttributeVector<ValueT> pointList(positions);
 
     PointIndexGrid::Ptr pointIndexGrid = createPointIndexGrid<PointIndexGrid>(pointList, xform);
-    return createPointDataGrid<PointDataGridT>(*pointIndexGrid, pointList, positionType, xform, positionDefaultValue);
+    return createPointDataGrid<CompressionT, PointDataGridT>(*pointIndexGrid, pointList, xform, positionDefaultValue);
 }
 
 

--- a/openvdb_points/unittest/TestIndexFilter.cc
+++ b/openvdb_points/unittest/TestIndexFilter.cc
@@ -471,7 +471,7 @@ TestIndexFilter::testAttributeHashFilter()
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // four points, two leafs
@@ -625,7 +625,7 @@ TestIndexFilter::testLevelSetFilter()
         const double voxelSize(1.0);
         math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-        points = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+        points = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     }
 
     // create a sphere levelset
@@ -732,7 +732,7 @@ TestIndexFilter::testLevelSetFilter()
         const double voxelSize(0.25);
         math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-        points = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+        points = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     }
 
     {
@@ -795,7 +795,7 @@ TestIndexFilter::testBBoxFilter()
     const float voxelSize(0.5);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // check one leaf per point

--- a/openvdb_points/unittest/TestPointAttribute.cc
+++ b/openvdb_points/unittest/TestPointAttribute.cc
@@ -67,7 +67,6 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestPointAttribute);
 void
 TestPointAttribute::testAppendDrop()
 {
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
     typedef TypedAttributeArray<float>   AttributeF;
     typedef TypedAttributeArray<int>     AttributeI;
 
@@ -80,7 +79,7 @@ TestPointAttribute::testAppendDrop()
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // check one leaf per point
@@ -327,7 +326,6 @@ TestPointAttribute::testAppendDrop()
 void
 TestPointAttribute::testRename()
 {
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
     typedef TypedAttributeArray<float>   AttributeF;
     typedef TypedAttributeArray<int>     AttributeI;
 
@@ -340,7 +338,7 @@ TestPointAttribute::testRename()
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // check one leaf per point
@@ -413,7 +411,6 @@ TestPointAttribute::testRename()
 void
 TestPointAttribute::testBloscCompress()
 {
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
     typedef TypedAttributeArray<int>     AttributeI;
 
     std::vector<Vec3s> positions;
@@ -427,7 +424,7 @@ TestPointAttribute::testBloscCompress()
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // check two leaves

--- a/openvdb_points/unittest/TestPointConversion.cc
+++ b/openvdb_points/unittest/TestPointConversion.cc
@@ -263,8 +263,7 @@ TestPointConversion::testPointConversion()
     openvdb::math::Transform::Ptr transform(openvdb::math::Transform::createLinearTransform(voxelSize));
 
     PointIndexGrid::Ptr pointIndexGrid = createPointIndexGrid<PointIndexGrid>(position, *transform);
-    PointDataGrid::Ptr pointDataGrid = createPointDataGrid<PointDataGrid>(*pointIndexGrid, position,
-                                            AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr pointDataGrid = createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, position, *transform);
 
     PointIndexTree& indexTree = pointIndexGrid->tree();
     PointDataTree& tree = pointDataGrid->tree();
@@ -474,8 +473,7 @@ TestPointConversion::testStride()
     openvdb::math::Transform::Ptr transform(openvdb::math::Transform::createLinearTransform(voxelSize));
 
     PointIndexGrid::Ptr pointIndexGrid = createPointIndexGrid<PointIndexGrid>(position, *transform);
-    PointDataGrid::Ptr pointDataGrid = createPointDataGrid<PointDataGrid>(*pointIndexGrid, position,
-                                            AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr pointDataGrid = createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, position, *transform);
 
     PointIndexTree& indexTree = pointIndexGrid->tree();
     PointDataTree& tree = pointDataGrid->tree();

--- a/openvdb_points/unittest/TestPointCount.cc
+++ b/openvdb_points/unittest/TestPointCount.cc
@@ -197,7 +197,6 @@ TestPointCount::testGroup()
     using namespace openvdb::tools;
     using namespace openvdb::math;
 
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
     typedef AttributeSet::Descriptor   Descriptor;
 
     // four points in the same leaf
@@ -211,7 +210,7 @@ TestPointCount::testGroup()
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // setup temp directory
@@ -389,7 +388,7 @@ TestPointCount::testGroup()
     positions.push_back(Vec3s(1, 20, 1));
     positions.push_back(Vec3s(1, 1, 20));
 
-    grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree2 = grid->tree();
 
     CPPUNIT_ASSERT_EQUAL(tree2.leafCount(), Index32(4));
@@ -450,7 +449,6 @@ TestPointCount::testOffsets()
     using namespace openvdb::tools;
     using namespace openvdb::math;
 
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
 
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
@@ -464,7 +462,7 @@ TestPointCount::testOffsets()
     positions.push_back(Vec3s(101, 1, 1));
     positions.push_back(Vec3s(101, 101, 1));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     { // all point offsets

--- a/openvdb_points/unittest/TestPointGroup.cc
+++ b/openvdb_points/unittest/TestPointGroup.cc
@@ -169,8 +169,6 @@ TestPointGroup::testDescriptor()
 void
 TestPointGroup::testAppendDrop()
 {
-	typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
-
     std::vector<Vec3s> positions;
     positions.push_back(Vec3s(1, 1, 1));
     positions.push_back(Vec3s(1, 10, 1));
@@ -180,7 +178,7 @@ TestPointGroup::testAppendDrop()
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // check one leaf per point
@@ -308,15 +306,13 @@ TestPointGroup::testAppendDrop()
 void
 TestPointGroup::testCompact()
 {
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
-
     std::vector<Vec3s> positions;
     positions.push_back(Vec3s(1, 1, 1));
 
     const float voxelSize(1.0);
     math::Transform::Ptr transform(math::Transform::createLinearTransform(voxelSize));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree = grid->tree();
 
     // check one leaf
@@ -412,8 +408,6 @@ TestPointGroup::testSet()
     using namespace openvdb;
     using namespace openvdb::tools;
 
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
-
     typedef PointIndexGrid PointIndexGrid;
 
     // four points in the same leaf
@@ -434,8 +428,7 @@ TestPointGroup::testSet()
     PointIndexGrid::Ptr pointIndexGrid =
         openvdb::tools::createPointIndexGrid<PointIndexGrid>(pointList, *transform);
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(*pointIndexGrid, pointList,
-                                                                 AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, pointList, *transform);
     PointDataTree& tree = grid->tree();
 
     appendGroup(tree, "test");
@@ -524,8 +517,6 @@ TestPointGroup::testFilter()
     using namespace openvdb;
     using namespace openvdb::tools;
 
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
-
     typedef PointIndexGrid PointIndexGrid;
 
     const float voxelSize(1.0);
@@ -546,8 +537,7 @@ TestPointGroup::testFilter()
         PointIndexGrid::Ptr pointIndexGrid =
             openvdb::tools::createPointIndexGrid<PointIndexGrid>(pointList, *transform);
 
-        grid = createPointDataGrid<PointDataGrid>(  *pointIndexGrid, pointList,
-                                                    AttributeVec3s::attributeType(), *transform);
+        grid = createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, pointList, *transform);
     }
 
     PointDataTree& tree = grid->tree();
@@ -638,8 +628,7 @@ TestPointGroup::testFilter()
         PointIndexGrid::Ptr pointIndexGrid =
             openvdb::tools::createPointIndexGrid<PointIndexGrid>(pointList, *transform);
 
-        grid = createPointDataGrid<PointDataGrid>(  *pointIndexGrid, pointList,
-                                                    AttributeVec3s::attributeType(), *transform);
+        grid = createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, pointList, *transform);
 
         PointDataTree& newTree = grid->tree();
 

--- a/openvdb_points/unittest/TestPointLoad.cc
+++ b/openvdb_points/unittest/TestPointLoad.cc
@@ -69,8 +69,6 @@ TestPointLoad::testLoad()
     using namespace openvdb;
     using namespace openvdb::tools;
 
-    typedef TypedAttributeArray<Vec3s>   AttributeVec3s;
-
     std::string tempDir(std::getenv("TMPDIR"));
     if (tempDir.empty())    tempDir = P_tmpdir;
 
@@ -90,7 +88,7 @@ TestPointLoad::testLoad()
     positions.push_back(Vec3s(1, 20, 1));
     positions.push_back(Vec3s(1, 1, 20));
 
-    PointDataGrid::Ptr grid = createPointDataGrid<PointDataGrid>(positions, AttributeVec3s::attributeType(), *transform);
+    PointDataGrid::Ptr grid = createPointDataGrid<NullCodec, PointDataGrid>(positions, *transform);
     PointDataTree& tree2 = grid->tree();
 
     CPPUNIT_ASSERT_EQUAL(tree2.leafCount(), Index32(4));

--- a/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
+++ b/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
@@ -50,6 +50,17 @@
 
 #include <openvdb_houdini/AttributeTransferUtil.h>
 
+#if (UT_MAJOR_VERSION_INT >= 15)
+    #include <GU/GU_PackedContext.h>
+#endif
+
+#if (UT_MAJOR_VERSION_INT >= 14)
+    #include <GU/GU_PrimPacked.h>
+    #include <GU/GU_PackedGeometry.h>
+    #include <GU/GU_PackedFragment.h>
+    #include <GU/GU_DetailHandle.h>
+#endif
+
 #include <CH/CH_Manager.h>
 #include <GA/GA_Types.h> // for GA_ATTRIB_POINT
 #include <SYS/SYS_Types.h> // for int32, float32, etc
@@ -68,26 +79,8 @@ enum COMPRESSION_TYPE
 {
     NONE = 0,
     TRUNCATE,
-    UNIT_VECTOR,
-    FIXED_POSITION_16,
-    FIXED_POSITION_8
+    UNIT_VECTOR
 };
-
-/// @brief Translate the type of a GA_Attribute into a position Attribute Type
-inline NamePair
-positionAttrTypeFromCompression(const int compression)
-{
-    if (compression > 0 && compression + FIXED_POSITION_16 - 1 == FIXED_POSITION_16) {
-        return TypedAttributeArray<Vec3<float>, FixedPointCodec<false> >::attributeType();
-    }
-    else if (compression > 0 && compression + FIXED_POSITION_16 - 1 == FIXED_POSITION_8) {
-        return TypedAttributeArray<Vec3<float>, FixedPointCodec<true> >::attributeType();
-    }
-
-    // compression == NONE
-
-    return TypedAttributeArray<Vec3<float> >::attributeType();
-}
 
 inline Name
 attrStringTypeFromGAAttribute(GA_Attribute const * attribute)
@@ -111,7 +104,15 @@ attrStringTypeFromGAAttribute(GA_Attribute const * attribute)
 
     const int16_t width = static_cast<int16_t>(tupleAIF->getTupleSize(attribute));
 
-    if (width == 1)
+    if (width == 3 || width == 4)
+    {
+        // note: process 4-component vectors as 3-component vectors for now
+
+        if (storage == GA_STORE_INT32)          return "vec3i";
+        else if (storage == GA_STORE_REAL32)    return "vec3s";
+        else if (storage == GA_STORE_REAL64)    return "vec3d";
+    }
+    else
     {
         if (storage == GA_STORE_BOOL)           return "bool";
         else if (storage == GA_STORE_INT16)     return "int16";
@@ -119,14 +120,6 @@ attrStringTypeFromGAAttribute(GA_Attribute const * attribute)
         else if (storage == GA_STORE_INT64)     return "int64";
         else if (storage == GA_STORE_REAL32)    return "float";
         else if (storage == GA_STORE_REAL64)    return "double";
-    }
-    else if (width == 3 || width == 4)
-    {
-        // note: process 4-component vectors as 3-component vectors for now
-
-        if (storage == GA_STORE_INT32)          return "vec3i";
-        else if (storage == GA_STORE_REAL32)    return "vec3s";
-        else if (storage == GA_STORE_REAL64)    return "vec3d";
     }
 
     std::stringstream ss; ss << "Unknown attribute type - " << attribute->getName();
@@ -302,21 +295,7 @@ convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree
 ////////////////////////////////////////
 
 
-struct AttributeInfo
-{
-    AttributeInfo(const Name& name,
-                  const int valueCompression,
-                  const bool bloscCompression)
-        : name(name)
-        , valueCompression(valueCompression)
-        , bloscCompression(bloscCompression) { }
-
-    Name name;
-    int valueCompression;
-    bool bloscCompression;
-}; // struct AttributeInfo
-
-typedef std::vector<AttributeInfo> AttributeInfoVec;
+typedef std::map<Name, std::pair<int, bool> > AttributeInfoMap;
 
 
 ///////////////////////////////////////
@@ -324,8 +303,8 @@ typedef std::vector<AttributeInfo> AttributeInfoVec;
 
 inline
 PointDataGrid::Ptr
-createPointDataGrid(const GU_Detail& ptGeo, const openvdb::NamePair& positionAttributeType,
-                    const AttributeInfoVec& attributes, const openvdb::math::Transform& transform)
+createPointDataGrid(const GU_Detail& ptGeo, const int compression,
+                    const AttributeInfoMap& attributes, const openvdb::math::Transform& transform)
 {
     // store point group information
 
@@ -344,8 +323,17 @@ createPointDataGrid(const GU_Detail& ptGeo, const openvdb::NamePair& positionAtt
 
     // Create PointDataGrid using position attribute
 
-    PointDataGrid::Ptr pointDataGrid = createPointDataGrid<PointDataGrid>(
-                            *pointIndexGrid, points, positionAttributeType, transform);
+    PointDataGrid::Ptr pointDataGrid;
+
+    if (compression == 1 /*FIXED_POSITION_16*/) {
+        pointDataGrid = createPointDataGrid<FixedPointCodec<false>, PointDataGrid>(*pointIndexGrid, points, transform);
+    }
+    else if (compression == 2 /*FIXED_POSITION_8*/) {
+        pointDataGrid = createPointDataGrid<FixedPointCodec<true>, PointDataGrid>(*pointIndexGrid, points, transform);
+    }
+    else /*NONE*/ {
+        pointDataGrid = createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, points, transform);
+    }
 
     PointIndexTree& indexTree = pointIndexGrid->tree();
     PointDataTree& tree = pointDataGrid->tree();
@@ -401,11 +389,11 @@ createPointDataGrid(const GU_Detail& ptGeo, const openvdb::NamePair& positionAtt
 
     // Add other attributes to PointDataGrid
 
-    for (AttributeInfoVec::const_iterator it = attributes.begin(),
+    for (AttributeInfoMap::const_iterator it = attributes.begin(),
                                           it_end = attributes.end(); it != it_end; ++it)
     {
-        const openvdb::Name name = it->name;
-        const int compression = it->valueCompression;
+        const openvdb::Name name = it->first;
+        const int compression = it->second.first;
 
         // skip position as this has already been added
 
@@ -444,12 +432,12 @@ createPointDataGrid(const GU_Detail& ptGeo, const openvdb::NamePair& positionAtt
 
     // Apply blosc compression to attributes
 
-    for (AttributeInfoVec::const_iterator   it = attributes.begin(),
+    for (AttributeInfoMap::const_iterator   it = attributes.begin(),
                                             it_end = attributes.end(); it != it_end; ++it)
     {
-        if (!it->bloscCompression)  continue;
+        if (!it->second.second)  continue;
 
-        bloscCompressAttribute(tree, it->name);
+        bloscCompressAttribute(tree, it->first);
     }
 
     return pointDataGrid;
@@ -826,7 +814,36 @@ SOP_OpenVDB_Points::cookMySop(OP_Context& context)
         }
 
         UT_String attrName;
-        AttributeInfoVec attributes;
+        AttributeInfoMap attributes;
+
+        GU_Detail nonConstDetail;
+        const GU_Detail* detail;
+
+        // unpack any packed primitives
+
+        for (GA_Iterator it(ptGeo->getPrimitiveRange()); !it.atEnd(); ++it)
+        {
+            GA_Offset offset = *it;
+
+            const GA_Primitive* primitive = ptGeo->getPrimitive(offset);
+            if (!primitive || !GU_PrimPacked::isPackedPrimitive(*primitive)) continue;
+
+            const GU_PrimPacked* packedPrimitive = static_cast<const GU_PrimPacked*>(primitive);
+
+            packedPrimitive->unpack(nonConstDetail);
+        }
+
+        if (ptGeo->getNumPoints() > 0 && nonConstDetail.getNumPoints() == 0) {
+            // only unpacked points exist so just use the input gdp
+
+            detail = ptGeo;
+        }
+        else {
+            // merge unpacked and packed point data
+
+            nonConstDetail.mergePoints(*ptGeo);
+            detail = &nonConstDetail;
+        }
 
         if (evalInt("mode", 0, time) != 0) {
             // Transfer point attributes.
@@ -835,7 +852,7 @@ SOP_OpenVDB_Points::cookMySop(OP_Context& context)
                     evalStringInst("attribute#", &i, attrName, 0, 0);
                     Name attributeName = Name(attrName);
 
-                    GA_ROAttributeRef attrRef = ptGeo->findPointAttribute(attributeName.c_str());
+                    GA_ROAttributeRef attrRef = detail->findPointAttribute(attributeName.c_str());
 
                     if (!attrRef.isValid()) continue;
 
@@ -872,12 +889,13 @@ SOP_OpenVDB_Points::cookMySop(OP_Context& context)
 
                     const bool bloscCompression = evalIntInst("blosccompression#", &i, 0, 0);
 
-                    attributes.push_back(AttributeInfo(attributeName, valueCompression, bloscCompression));
+                    attributes[attributeName] = std::pair<int, bool>(valueCompression, bloscCompression);
                 }
             }
         } else {
+
             // point attribute names
-            GA_AttributeDict::iterator iter = ptGeo->pointAttribs().begin(GA_SCOPE_PUBLIC);
+            GA_AttributeDict::iterator iter = detail->pointAttribs().begin(GA_SCOPE_PUBLIC);
 
             if (!iter.atEnd()) {
                 for (; !iter.atEnd(); ++iter) {
@@ -889,7 +907,7 @@ SOP_OpenVDB_Points::cookMySop(OP_Context& context)
                         if (attrName == "P") continue;
 
                         // when converting all attributes apply no compression
-                        attributes.push_back(AttributeInfo(attrName, 0, false));
+                        attributes[attrName] = std::pair<int, bool>(0, false);
                     }
                 }
             }
@@ -899,10 +917,7 @@ SOP_OpenVDB_Points::cookMySop(OP_Context& context)
 
         const int positionCompression = evalInt("poscompression", 0, time);
 
-        const openvdb::NamePair positionAttributeType =
-                    positionAttrTypeFromCompression(positionCompression);
-
-        PointDataGrid::Ptr pointDataGrid = createPointDataGrid(*ptGeo, positionAttributeType, attributes, *transform);
+        PointDataGrid::Ptr pointDataGrid = createPointDataGrid(*detail, positionCompression, attributes, *transform);
 
         UT_String nameStr = "";
         evalString(nameStr, "name", 0, time);


### PR DESCRIPTION
OpenVDB Points SOP now supports packed prims (simply unpacks on conversion). Also tackles a request so as not to require the position type as a string, but as a compile time codec during point conversion.