### PR TITLE
Allow mismatching descriptors when replacing attribute set.

### DIFF
--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -346,10 +346,13 @@ public:
     /// @brief Compact all attributes in attribute set.
     void compactAttributes();
 
-    /// @brief Swap the underlying attribute set with the given @a attributeSet.
+    /// @brief Replace the underlying attribute set with the given @a attributeSet.
     /// This leaf will assume ownership of the given attribute set. The descriptors must
     /// match and the voxel offsets values will need updating if the point order is different.
-    void swap(AttributeSet* attributeSet);
+    /// @param allowMismatchingDescriptors Whether or not the old and new descriptors must match
+    /// for the replacement to be allowed. If @c false and the descriptors do not match then
+    /// @c ValueError is thrown.
+    void replaceAttributeSet(AttributeSet* attributeSet, bool allowMismatchingDescriptors = false);
 
     /// @brief Replace the descriptor with a new one
     /// The new Descriptor must exactly match the old one
@@ -780,13 +783,13 @@ PointDataLeafNode<T, Log2Dim>::compactAttributes()
 
 template<typename T, Index Log2Dim>
 inline void
-PointDataLeafNode<T, Log2Dim>::swap(AttributeSet* attributeSet)
+PointDataLeafNode<T, Log2Dim>::replaceAttributeSet(AttributeSet* attributeSet, bool allowMismatchingDescriptors)
 {
     if (!attributeSet) {
-        OPENVDB_THROW(ValueError, "Cannot swap with a null attribute set");
+        OPENVDB_THROW(ValueError, "Cannot replace with a null attribute set");
     }
 
-    if (mAttributeSet->descriptor() != attributeSet->descriptor()) {
+    if (!allowMismatchingDescriptors && mAttributeSet->descriptor() != attributeSet->descriptor()) {
         OPENVDB_THROW(ValueError, "Attribute set descriptors are not equal.");
     }
 

--- a/openvdb_points/unittest/TestPointDataLeaf.cc
+++ b/openvdb_points/unittest/TestPointDataLeaf.cc
@@ -382,7 +382,7 @@ TestPointDataLeaf::testOffsets()
 
             AttributeSet* newSet = new AttributeSet(leafNode->attributeSet(), numAttributes);
             newSet->replace("density", AttributeS::create(numAttributes+1));
-            leafNode->swap(newSet);
+            leafNode->replaceAttributeSet(newSet);
 
             std::vector<LeafType::ValueType> offsets(LeafType::SIZE);
             offsets.back() = numAttributes;
@@ -1119,24 +1119,26 @@ TestPointDataLeaf::testSwap()
     newAttributeSet->appendAttribute("density", AttributeF::attributeType());
     newAttributeSet->appendAttribute("id", AttributeI::attributeType());
 
-    leaf.swap(newAttributeSet);
+    leaf.replaceAttributeSet(newAttributeSet);
 
     CPPUNIT_ASSERT_EQUAL(newArrayLength, leaf.attributeSet().get("density")->size());
     CPPUNIT_ASSERT_EQUAL(newArrayLength, leaf.attributeSet().get("id")->size());
 
     // ensure we refuse to swap when the attribute set is null
 
-    CPPUNIT_ASSERT_THROW(leaf.swap(0), openvdb::ValueError);
+    CPPUNIT_ASSERT_THROW(leaf.replaceAttributeSet(nullptr), openvdb::ValueError);
 
-    // ensure we refuse to swap when the descriptors do not match
+    // ensure we refuse to swap when the descriptors do not match, unless we explicitly allow a mismatch.
 
     Descriptor::Ptr descrB = Descriptor::create(AttributeVec3s::attributeType());
     AttributeSet* attributeSet = new AttributeSet(descrB, newArrayLength);
 
     attributeSet->appendAttribute("extra", AttributeF::attributeType());
 
-    CPPUNIT_ASSERT_THROW(leaf.swap(attributeSet), openvdb::ValueError);
-    delete attributeSet;
+    CPPUNIT_ASSERT_THROW(leaf.replaceAttributeSet(attributeSet), openvdb::ValueError);
+
+    leaf.replaceAttributeSet(attributeSet, true);
+    CPPUNIT_ASSERT_EQUAL(const_cast<AttributeSet*>(&leaf.attributeSet()), attributeSet);
 }
 
 void


### PR DESCRIPTION
Renamed swap to replaceAttributeSet.