### PR TITLE
Remove Strided and Interleaved template arguments.

### DIFF
--- a/openvdb_points/tools/AttributeArray.cc
+++ b/openvdb_points/tools/AttributeArray.cc
@@ -161,14 +161,6 @@ AttributeArray::unregisterType(const NamePair& type)
 
 
 void
-AttributeArray::setInterleaved(bool state)
-{
-    if (state)  mFlags |= Int16(INTERLEAVED);
-    else mFlags &= ~Int16(INTERLEAVED);
-}
-
-
-void
 AttributeArray::setTransient(bool state)
 {
     if (state) mFlags |= Int16(TRANSIENT);

--- a/openvdb_points/unittest/TestPointConversion.cc
+++ b/openvdb_points/unittest/TestPointConversion.cc
@@ -271,12 +271,12 @@ TestPointConversion::testPointConversion()
     // add id and populate
 
     appendAttribute<int>(tree, "id");
-    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>, false>(tree, indexTree, "id", id);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>>(tree, indexTree, "id", id);
 
     // add uniform and populate
 
     appendAttribute<float>(tree, "uniform");
-    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<float>, false>(tree, indexTree, "uniform", uniform);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<float>>(tree, indexTree, "uniform", uniform);
 
     // add string and populate
 
@@ -296,7 +296,7 @@ TestPointConversion::testPointConversion()
     inserter.insert("testA");
     inserter.insert("testB");
 
-    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<openvdb::Name>, false>(tree, indexTree, "string", string);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<openvdb::Name>>(tree, indexTree, "string", string);
 
     // add group and set membership
 
@@ -509,12 +509,12 @@ TestPointConversion::testStride()
     // add id and populate
 
     appendAttribute<int>(tree, "id");
-    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>, false>(tree, indexTree, "id", id);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>>(tree, indexTree, "id", id);
 
     // add xyz and populate
 
     appendAttribute<int>(tree, "xyz", 0, /*stride=*/3);
-    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>, true>(tree, indexTree, "xyz", xyz, /*stride=*/3);
+    populateAttribute<PointDataTree, PointIndexTree, AttributeWrapper<int>>(tree, indexTree, "xyz", xyz, /*stride=*/3);
 
     // create accessor and iterator for Point Data Tree
 

--- a/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
+++ b/openvdb_points_houdini/houdini/SOP_OpenVDB_Points.cc
@@ -92,7 +92,7 @@ convertSegmentsFromHoudini( PointDataTree& tree, const PointIndexTree& indexTree
 
     appendAttribute<ValueType>(tree, name, zeroVal<ValueType>(), count);
 
-    populateAttribute<PointDataTree, PointIndexTree, HoudiniOffsetAttribute, true>(tree, indexTree, name, houdiniOffsets, count);
+    populateAttribute<PointDataTree, PointIndexTree, HoudiniOffsetAttribute>(tree, indexTree, name, houdiniOffsets, count);
 }
 
 template <typename ValueType, bool Strided, typename CodecType = NullCodec>
@@ -116,14 +116,7 @@ convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree
     appendAttribute<ValueType, CodecType>(tree, name, zeroVal<ValueType>(), stride, defaultValue);
 
     HoudiniAttribute houdiniAttribute(*attribute);
-    if (Strided) {
-        assert(stride > 1);
-        populateAttribute<PointDataTree, PointIndexTree, HoudiniAttribute, true>(tree, indexTree, name, houdiniAttribute, stride);
-    }
-    else {
-        assert(stride == 1);
-        populateAttribute<PointDataTree, PointIndexTree, HoudiniAttribute, false>(tree, indexTree, name, houdiniAttribute);
-    }
+    populateAttribute<PointDataTree, PointIndexTree, HoudiniAttribute>(tree, indexTree, name, houdiniAttribute, stride);
 }
 
 void
@@ -142,7 +135,7 @@ convertAttributeFromHoudini(PointDataTree& tree, const PointIndexTree& indexTree
     if (attribute->getAIFStringTuple()) {
         appendAttribute<Name>(tree, name);
         HoudiniStringAttribute houdiniAttribute(*attribute);
-        populateAttribute<PointDataTree, PointIndexTree, HoudiniStringAttribute, false>(tree, indexTree, name, houdiniAttribute);
+        populateAttribute<PointDataTree, PointIndexTree, HoudiniStringAttribute>(tree, indexTree, name, houdiniAttribute);
         return;
     }
 


### PR DESCRIPTION
All striding checks are now done at run-time.