### PR TITLE
Allow any AttributeSet to be constructed from a Descriptor

### DIFF
--- a/openvdb_points/tools/AttributeSet.h
+++ b/openvdb_points/tools/AttributeSet.h
@@ -98,11 +98,20 @@ public:
 
     AttributeSet();
 
-    /// Construct from the given descriptor
-    explicit AttributeSet(const DescriptorPtr&, size_t arrayLength = 1);
+    /// Construct a new AttributeSet from the given AttributeSet.
+    /// @param attributeSet the old attribute set
+    /// @param arrayLength the desired length of the arrays in the new AttributeSet
+    /// @note This constructor is typically used to resize an existing AttributeSet as
+    ///       it transfers attribute metadata such as hidden and transient flags
+    AttributeSet(const AttributeSet& attributeSet, size_t arrayLength);
 
-    /// Construct from the given AttributeSet
-    AttributeSet(const AttributeSet&, size_t arrayLength);
+    /// Construct a new AttributeSet from the given Descriptor.
+    /// @param descriptor stored in the new AttributeSet and used in construction
+    /// @param arrayLength the desired length of the arrays in the new AttributeSet
+    /// @note Descriptors do not store attribute metadata such as hidden and transient flags
+    ///       which live on the AttributeArrays, so for constructing from an existing AttributeSet
+    ///       use the AttributeSet(const AttributeSet&, size_t) constructor instead
+    explicit AttributeSet(const DescriptorPtr& descriptor, size_t arrayLength = 1);
 
     /// Shallow copy constructor, the descriptor and attribute arrays will be shared.
     AttributeSet(const AttributeSet&);

--- a/openvdb_points/tools/PointDataGrid.h
+++ b/openvdb_points/tools/PointDataGrid.h
@@ -706,6 +706,13 @@ template<typename T, Index Log2Dim>
 inline void
 PointDataLeafNode<T, Log2Dim>::initializeAttributes(const Descriptor::Ptr& descriptor, const size_t arrayLength)
 {
+    if (descriptor->size() != 1 ||
+        descriptor->find("P") == AttributeSet::INVALID_POS ||
+        descriptor->valueType(0) != typeNameAsString<Vec3f>())
+    {
+        OPENVDB_THROW(IndexError, "Initializing attributes only allowed with one Vec3f position attribute.");
+    }
+
     mAttributeSet.reset(new AttributeSet(descriptor, arrayLength));
 }
 

--- a/openvdb_points/unittest/TestAttributeSet.cc
+++ b/openvdb_points/unittest/TestAttributeSet.cc
@@ -186,6 +186,11 @@ TestAttributeSet::testAttributeSetDescriptor()
 
     using Descriptor        = openvdb::tools::AttributeSet::Descriptor;
 
+    { // error on invalid construction
+        Descriptor::Ptr invalidDescr = Descriptor::create(AttributeVec3f::attributeType());
+        CPPUNIT_ASSERT_THROW(invalidDescr->duplicateAppend("P", AttributeS::attributeType()), openvdb::KeyError);
+    }
+
     Descriptor::Ptr descrA = Descriptor::create(AttributeVec3f::attributeType());
 
     descrA = descrA->duplicateAppend("density", AttributeS::attributeType());
@@ -518,17 +523,11 @@ TestAttributeSet::testAttributeSet()
     Descriptor::NameToPosMap groupMap;
     openvdb::MetaMap metadata;
 
-    { // error on invalid construction
-        CPPUNIT_ASSERT_THROW(AttributeSet(Descriptor::Ptr(new Descriptor), size_t(1)), openvdb::IndexError);
-        CPPUNIT_ASSERT_THROW(AttributeSet(Descriptor::create(AttributeS::attributeType()), size_t(1)), openvdb::IndexError);
-
-        Descriptor::Ptr invalidDescr = Descriptor::create(AttributeVec3s::attributeType());
-        invalidDescr = invalidDescr->duplicateAppend("test", AttributeVec3s::attributeType());
-        CPPUNIT_ASSERT_THROW(AttributeSet attrSet(invalidDescr), openvdb::IndexError);
-        invalidDescr = Descriptor::Ptr(new Descriptor)->duplicateAppend("P2", AttributeVec3s::attributeType());
-        CPPUNIT_ASSERT_THROW(AttributeSet attrSet(invalidDescr), openvdb::IndexError);
-        invalidDescr = Descriptor::Ptr(new Descriptor)->duplicateAppend("P", AttributeS::attributeType());
-        CPPUNIT_ASSERT_THROW(AttributeSet attrSet(invalidDescr), openvdb::IndexError);
+    { // construction
+        Descriptor::Ptr descr = Descriptor::create(AttributeVec3s::attributeType());
+        descr = descr->duplicateAppend("test", AttributeI::attributeType());
+        AttributeSet attrSet(descr);
+        CPPUNIT_ASSERT_EQUAL(attrSet.size(), size_t(2));
     }
 
     { // transfer of flags on construction


### PR DESCRIPTION
This removes the restriction that an AttributeSet must have just position to be constructed and places it in the PointDataLeaf instead.